### PR TITLE
[FE] Navbar컴포넌트 일부완성

### DIFF
--- a/front/src/api/get.ts
+++ b/front/src/api/get.ts
@@ -1,0 +1,10 @@
+import axios from 'axios';
+
+const getGroups = async (generation: string) => {
+  const response = await axios.get(
+    `${import.meta.env.VITE_API_URL}/api/groups?generation=${generation}`
+  );
+  return response.data;
+};
+
+export { getGroups };

--- a/front/src/api/get.ts
+++ b/front/src/api/get.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 const getGroups = async (generation: string) => {
   const response = await axios.get(
-    `${import.meta.env.VITE_API_URL}/api/groups?generation=${generation}`
+    `${import.meta.env.VITE_API_URL}/api/project?generation=${generation}`
   );
   return response.data;
 };

--- a/front/src/api/post.ts
+++ b/front/src/api/post.ts
@@ -2,7 +2,7 @@ import { FormState } from '@type/RegisterForm';
 import axios from 'axios';
 
 const postRegister = async (data: FormState) => {
-  const response = await axios.post('/api/register', data);
+  const response = await axios.post(`${import.meta.env.VITE_API_URL}/api/project`, data);
   return response.data;
 };
 

--- a/front/src/boundary/CustomErrorBoundary.tsx
+++ b/front/src/boundary/CustomErrorBoundary.tsx
@@ -1,14 +1,28 @@
+import Loading from '@component/atom/Loading';
+import { QueryErrorResetBoundary } from '@tanstack/react-query';
 import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
 import CustomErrorFallback from './CustomErrorFallback';
 
-import Loading from '@/component/atom/Loading';
-
 export default function CustomErrorBoundary({ children }: { children: React.ReactElement }) {
+  console.log(children);
   return (
-    <ErrorBoundary FallbackComponent={CustomErrorFallback}>
-      <Suspense fallback={<Loading />}>{children}</Suspense>
-    </ErrorBoundary>
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary onReset={reset} FallbackComponent={CustomErrorFallback}>
+          <div className='w-full'>
+            <Suspense
+              fallback={
+                <div className='flex h-full w-full items-center justify-center'>
+                  <Loading />
+                </div>
+              }>
+              {children}
+            </Suspense>
+          </div>
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
   );
 }

--- a/front/src/boundary/CustomErrorBoundary.tsx
+++ b/front/src/boundary/CustomErrorBoundary.tsx
@@ -5,8 +5,11 @@ import { ErrorBoundary } from 'react-error-boundary';
 
 import CustomErrorFallback from './CustomErrorFallback';
 
-export default function CustomErrorBoundary({ children }: { children: React.ReactElement }) {
-  console.log(children);
+type Props = {
+  children: React.ReactNode;
+};
+
+export default function CustomErrorBoundary({ children }: Props) {
   return (
     <QueryErrorResetBoundary>
       {({ reset }) => (

--- a/front/src/boundary/CustomErrorFallback.tsx
+++ b/front/src/boundary/CustomErrorFallback.tsx
@@ -1,11 +1,12 @@
+import Loading from '@component/atom/Loading';
 import { useQueryErrorResetBoundary } from '@tanstack/react-query';
-import { FallbackProps } from 'react-error-boundary';
 
-import { getErrorByCode } from './toastError';
+type Props = {
+  resetErrorBoundary: () => void;
+};
 
-export default function CustomErrorFallBack({ error, resetErrorBoundary }: FallbackProps) {
+export default function CustomErrorFallback({ resetErrorBoundary }: Props) {
   const { reset } = useQueryErrorResetBoundary();
-  const errorData = getErrorByCode(error);
 
   const handleClickReset = () => {
     resetErrorBoundary();
@@ -13,11 +14,13 @@ export default function CustomErrorFallBack({ error, resetErrorBoundary }: Fallb
   };
 
   return (
-    <div>
-      <p>{error.toString()}</p>
-      <h1>{errorData?.code}</h1>
-      <h2>{errorData?.message}</h2>
-      <button onClick={handleClickReset}>재시도</button>
+    <div className='flex flex-col items-center gap-4'>
+      <Loading />
+      <button
+        onClick={handleClickReset}
+        className='flex items-center gap-2 rounded-lg bg-blue px-6 py-2 text-white shadow-md transition-all duration-200 hover:bg-opacity-90 active:scale-95'>
+        재시도
+      </button>
     </div>
   );
 }

--- a/front/src/boundary/CustomQueryProvider.tsx
+++ b/front/src/boundary/CustomQueryProvider.tsx
@@ -4,17 +4,21 @@ type Props = {
   children: React.ReactNode;
 };
 
-export default function CustomQueryProvider({ children }: Props) {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: 1
-      },
-      mutations: {
-        retry: 1
-      }
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      staleTime: 5 * 60 * 1000,
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+      refetchOnReconnect: false
+    },
+    mutations: {
+      retry: 1
     }
-  });
+  }
+});
 
+export default function CustomQueryProvider({ children }: Props) {
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 }

--- a/front/src/component/atom/Loading.tsx
+++ b/front/src/component/atom/Loading.tsx
@@ -1,11 +1,11 @@
 export default function Loading() {
   return (
-    <div className='fixed inset-0 z-50 flex items-center justify-center bg-white bg-opacity-75'>
-      <div className='relative'>
-        <div className='h-12 w-12 animate-spin rounded-full border-4 border-blue-200' />
-        <div className='absolute left-0 top-0 h-12 w-12 animate-spin rounded-full border-t-4 border-blue-500' />
+    <div className='flex items-center justify-center bg-white bg-opacity-75 p-4 text-center'>
+      <div className='relative inline-flex'>
+        <div className='absolute h-12 w-12 rounded-full border-4 border-gray-200' />
+        <div className='h-12 w-12 animate-spin rounded-full border-4 border-blue border-t-transparent [animation-duration:1.5s]' />
       </div>
-      <span className='ml-3 text-lg font-medium text-blue-500'>Loading...</span>
+      <span className='text-lg font-medium text-gray'>Loading...</span>
     </div>
   );
 }

--- a/front/src/component/atom/Select.tsx
+++ b/front/src/component/atom/Select.tsx
@@ -1,0 +1,29 @@
+type Props<T extends string> = {
+  cssOption?: string;
+  options: ReadonlyArray<{ readonly value: T; readonly label: string }>;
+  value: T;
+  onChange: (value: T) => void;
+};
+
+export default function Select<T extends string>({
+  cssOption,
+  options = [] as ReadonlyArray<{ value: T; label: string }>,
+  value,
+  onChange
+}: Props<T>) {
+  return (
+    <select
+      className={`min-w-0 bg-transparent ${cssOption}`}
+      value={value}
+      onChange={(e) => onChange(e.target.value as T)}>
+      {options.map((option) => (
+        <option
+          key={option.value}
+          value={option.value}
+          className='overflow-hidden text-ellipsis whitespace-nowrap bg-white text-black'>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/front/src/component/molecule/NavbarMenu.tsx
+++ b/front/src/component/molecule/NavbarMenu.tsx
@@ -1,0 +1,17 @@
+import H1 from '@component/atom/H1';
+import NavbarMenuItem from '@component/molecule/NavbarMenuItem';
+import { MENU_ITEMS } from '@constant/NavbarMenu';
+import { useLocation } from 'react-router-dom';
+
+export default function NavbarMenu() {
+  const { pathname } = useLocation();
+
+  return (
+    <div className='flex flex-col gap-8 md:gap-16'>
+      <H1 cssOption='mt-16 md:mt-40 text-14 md:text-16 whitespace-nowrap' content='MENU' />
+      {MENU_ITEMS.map((item) => (
+        <NavbarMenuItem key={item.path} item={item} isActive={pathname === item.path} />
+      ))}
+    </div>
+  );
+}

--- a/front/src/component/molecule/NavbarMenuItem.tsx
+++ b/front/src/component/molecule/NavbarMenuItem.tsx
@@ -1,0 +1,27 @@
+import Img from '@component/atom/Img';
+import P from '@component/atom/P';
+import { MenuItem } from '@type/Navbar';
+import { Link } from 'react-router-dom';
+
+type Props = {
+  item: MenuItem;
+  isActive: boolean;
+};
+
+export default function NavbarMenuItem({ item, isActive }: Props) {
+  return (
+    <Link to={item.path}>
+      <div
+        className={`flex cursor-pointer items-center gap-4 md:gap-8 ${
+          isActive ? 'text-black' : 'text-gray hover:text-black'
+        }`}>
+        <Img
+          src={isActive ? item.activeIcon : item.inactiveIcon}
+          alt='메뉴제목 텍스트'
+          cssOption='w-4 md:w-6'
+        />
+        <P content={item.label} cssOption='text-12 md:text-14 whitespace-nowrap' />
+      </div>
+    </Link>
+  );
+}

--- a/front/src/component/molecule/NavbarSelect.tsx
+++ b/front/src/component/molecule/NavbarSelect.tsx
@@ -55,7 +55,7 @@ export default function NavbarSelect({
         onChange={handleGenerationChange}
       />
       <Select
-        cssOption='text-12 md:text-14 md:px-4 text-ellipsis cursor-pointer text-gray hover:font-semibold truncate flex-1'
+        cssOption='text-12 md:text-14 md:px-2 text-ellipsis cursor-pointer text-gray hover:font-semibold truncate flex-1'
         options={groupOption}
         value={selectedGroup}
         onChange={setSelectedGroup}

--- a/front/src/component/molecule/NavbarSelect.tsx
+++ b/front/src/component/molecule/NavbarSelect.tsx
@@ -1,0 +1,65 @@
+import Select from '@component/atom/Select';
+import { BOOST_CAMP_OPTION, GENERATION_OPTIONS, GENERATION_VALUE } from '@constant/NavbarSelect';
+import { Generation } from '@type/Navbar';
+import { GroupOption } from '@type/Navbar';
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+type Props = {
+  generation: Generation;
+  selectedGroup: string;
+  setGeneration: (value: Generation) => void;
+  setSelectedGroup: (value: string) => void;
+  groupOption: GroupOption[];
+};
+
+export default function NavbarSelect({
+  generation,
+  selectedGroup,
+  setGeneration,
+  setSelectedGroup,
+  groupOption = []
+}: Props) {
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (pathname === '/project') {
+      setGeneration(GENERATION_VALUE.NINTH);
+      if (groupOption.length > 0) {
+        setSelectedGroup(groupOption[0].value);
+      }
+    } else {
+      setGeneration(GENERATION_VALUE.ALL);
+      setSelectedGroup(BOOST_CAMP_OPTION[0].value);
+    }
+  }, [pathname, groupOption]);
+
+  const handleGenerationChange = (value: Generation) => {
+    setGeneration(value);
+    if (value === GENERATION_VALUE.ALL) {
+      setSelectedGroup(BOOST_CAMP_OPTION[0].value);
+      navigate('/');
+    } else {
+      setSelectedGroup('');
+      navigate('/project');
+    }
+  };
+
+  return (
+    <div className='mt-8 flex w-full min-w-0 items-center justify-between rounded-1.5 border-1.5 border-solid border-gray p-4 md:mt-16 md:gap-[4px] md:p-8'>
+      <Select
+        cssOption='text-12 md:text-14 md:px-2 text-ellipsis cursor-pointer hover:font-semibold truncate'
+        options={GENERATION_OPTIONS}
+        value={generation}
+        onChange={handleGenerationChange}
+      />
+      <Select
+        cssOption='text-12 md:text-14 md:px-4 text-ellipsis cursor-pointer text-gray hover:font-semibold truncate flex-1'
+        options={groupOption}
+        value={selectedGroup}
+        onChange={setSelectedGroup}
+      />
+    </div>
+  );
+}

--- a/front/src/component/molecule/NavbarTitle.tsx
+++ b/front/src/component/molecule/NavbarTitle.tsx
@@ -1,0 +1,22 @@
+import H1 from '@component/atom/H1';
+import P from '@component/atom/P';
+import { useNavigate } from 'react-router-dom';
+
+export default function NavbarTitle() {
+  const navigate = useNavigate();
+
+  const navigateMain = () => {
+    navigate('/');
+  };
+
+  return (
+    <div className='w-full overflow-hidden'>
+      <div
+        className='flex min-w-0 cursor-pointer items-center gap-2 md:gap-4'
+        onClick={navigateMain}>
+        <P cssOption='text-16 md:text-20 lg:text-24 shrink-0' content='🐥' />
+        <H1 cssOption='font-bold text-16 md:text-20 lg:text-24 truncate' content='WatchDucks' />
+      </div>
+    </div>
+  );
+}

--- a/front/src/component/molecule/NavigateButton.tsx
+++ b/front/src/component/molecule/NavigateButton.tsx
@@ -13,7 +13,7 @@ export default function NavigateButton({ path = '', content = '', cssOption }: P
     navigate(path);
   };
   return (
-    <div className='flex justify-center px-[40px] py-[20px]'>
+    <div className='flex w-full justify-center'>
       <Button cssOption={cssOption} content={content} onClick={handleNavigate} />
     </div>
   );

--- a/front/src/component/organism/NavBar.tsx
+++ b/front/src/component/organism/NavBar.tsx
@@ -13,7 +13,7 @@ export default function Navbar() {
   const [selectedGroup, setSelectedGroup] = useState<string>(BOOST_CAMP_OPTION[0].value);
 
   return (
-    <div className='flex flex-col items-start gap-16 px-24 pt-24'>
+    <div className='flex flex-col gap-16 px-24 pt-24'>
       <NavbarTitle />
       <CustomErrorBoundary>
         <NavbarSelectWrapper

--- a/front/src/component/organism/NavBar.tsx
+++ b/front/src/component/organism/NavBar.tsx
@@ -27,7 +27,7 @@ export default function Navbar() {
       <NavigateButton
         path='/register'
         content='프로젝트 등록하러가기'
-        cssOption='bg-blue rounded-[10px] text-white text-12 md:text-14 p-16 flex items-center justify-center whitespace-nowrap hover:text-black'
+        cssOption='bg-blue rounded-10 text-white text-10 md:text-12 p-16 flex items-center whitespace-nowrap hover:text-black'
       />
     </div>
   );

--- a/front/src/component/organism/NavBar.tsx
+++ b/front/src/component/organism/NavBar.tsx
@@ -1,0 +1,34 @@
+import CustomErrorBoundary from '@boundary/CustomErrorBoundary';
+import NavbarMenu from '@component/molecule/NavbarMenu';
+import NavbarTitle from '@component/molecule/NavbarTitle';
+import NavbarSelectWrapper from '@component/organism/NavbarSelectWrapper';
+import { BOOST_CAMP_OPTION, GENERATION_VALUE } from '@constant/NavbarSelect';
+import { Generation } from '@type/Navbar';
+import { useState } from 'react';
+
+import NavigateButton from '../molecule/NavigateButton';
+
+export default function Navbar() {
+  const [generation, setGeneration] = useState<Generation>(GENERATION_VALUE.ALL);
+  const [selectedGroup, setSelectedGroup] = useState<string>(BOOST_CAMP_OPTION[0].value);
+
+  return (
+    <div className='flex flex-col items-start gap-16 px-24 pt-24'>
+      <NavbarTitle />
+      <CustomErrorBoundary>
+        <NavbarSelectWrapper
+          generation={generation}
+          selectedGroup={selectedGroup}
+          setGeneration={setGeneration}
+          setSelectedGroup={setSelectedGroup}
+        />
+      </CustomErrorBoundary>
+      <NavbarMenu />
+      <NavigateButton
+        path='/register'
+        content='프로젝트 등록하러가기'
+        cssOption='bg-blue rounded-[10px] text-white text-12 md:text-14 p-16 flex items-center justify-center whitespace-nowrap hover:text-black'
+      />
+    </div>
+  );
+}

--- a/front/src/component/organism/NavbarSelectWrapper.tsx
+++ b/front/src/component/organism/NavbarSelectWrapper.tsx
@@ -17,7 +17,8 @@ export default function NavbarSelectWrapper({
   setGeneration,
   setSelectedGroup
 }: Props) {
-  const { data: projectGroups } = useGroups(generation);
+  // const { data: projectGroups } = useGroups(generation);
+  const projectGroups = [];
   const groupOptions: GroupOption[] = Array.isArray(projectGroups) ? projectGroups : [];
   // api 연결시 isArray 제거
 

--- a/front/src/component/organism/NavbarSelectWrapper.tsx
+++ b/front/src/component/organism/NavbarSelectWrapper.tsx
@@ -17,10 +17,8 @@ export default function NavbarSelectWrapper({
   setGeneration,
   setSelectedGroup
 }: Props) {
-  // const { data: projectGroups } = useGroups(generation);
-  const projectGroups = [];
+  const { data: projectGroups } = useGroups(generation);
   const groupOptions: GroupOption[] = Array.isArray(projectGroups) ? projectGroups : [];
-  // api 연결시 isArray 제거
 
   const groupOption: GroupOption[] =
     generation === GENERATION_VALUE.ALL ? [...BOOST_CAMP_OPTION] : groupOptions;

--- a/front/src/component/organism/NavbarSelectWrapper.tsx
+++ b/front/src/component/organism/NavbarSelectWrapper.tsx
@@ -1,0 +1,36 @@
+import NavbarSelect from '@component/molecule/NavbarSelect';
+import { GENERATION_VALUE, BOOST_CAMP_OPTION } from '@constant/NavbarSelect';
+import { useGroups } from '@hook/useGroup';
+import { Generation } from '@type/Navbar';
+import { GroupOption } from '@type/Navbar';
+
+type Props = {
+  generation: Generation;
+  selectedGroup: string;
+  setGeneration: (value: Generation) => void;
+  setSelectedGroup: (value: string) => void;
+};
+
+export default function NavbarSelectWrapper({
+  generation,
+  selectedGroup,
+  setGeneration,
+  setSelectedGroup
+}: Props) {
+  const { data: projectGroups } = useGroups(generation);
+  const groupOptions: GroupOption[] = Array.isArray(projectGroups) ? projectGroups : [];
+  // api 연결시 isArray 제거
+
+  const groupOption: GroupOption[] =
+    generation === GENERATION_VALUE.ALL ? [...BOOST_CAMP_OPTION] : groupOptions;
+
+  return (
+    <NavbarSelect
+      generation={generation}
+      selectedGroup={selectedGroup}
+      setGeneration={setGeneration}
+      setSelectedGroup={setSelectedGroup}
+      groupOption={groupOption}
+    />
+  );
+}

--- a/front/src/component/organism/RegisterDescription.tsx
+++ b/front/src/component/organism/RegisterDescription.tsx
@@ -10,7 +10,7 @@ export default function RegisterDescription() {
       <NavigateButton
         path='/'
         content='메인으로'
-        cssOption='bg-blue w-full rounded-[10px] text-white text-[25px] px-[100px] py-[10px] flex items-center justify-center whitespace-nowrap hover:text-black'
+        cssOption='bg-blue w-full rounded-[10px] text-white text-[25px] px-[100px] py-[10px] flex items-center justify-center whitespace-nowrap hover:text-black mx-[40px] my-[20px]'
       />
     </div>
   );

--- a/front/src/component/template/MainPageLayout.tsx
+++ b/front/src/component/template/MainPageLayout.tsx
@@ -4,10 +4,10 @@ import { Outlet } from 'react-router-dom';
 export default function MainPageLayout() {
   return (
     <div className='flex min-h-screen bg-gray-50'>
-      <div className='w-[25%] border-r border-gray-200'>
+      <div className='w-[20%] border-r border-gray-200'>
         <NavbarLayout />
       </div>
-      <main className='w-[75%] flex-1'>
+      <main className='w-[80%] flex-1'>
         <Outlet />
       </main>
     </div>

--- a/front/src/component/template/MainPageLayout.tsx
+++ b/front/src/component/template/MainPageLayout.tsx
@@ -4,10 +4,10 @@ import { Outlet } from 'react-router-dom';
 export default function MainPageLayout() {
   return (
     <div className='flex min-h-screen bg-gray-50'>
-      <div className='w-[20%] border-r border-gray-200'>
+      <div className='w-[25%] border-r border-gray-200'>
         <NavbarLayout />
       </div>
-      <main className='w-[80%] flex-1'>
+      <main className='w-[75%] flex-1'>
         <Outlet />
       </main>
     </div>

--- a/front/src/constant/NavbarMenu.ts
+++ b/front/src/constant/NavbarMenu.ts
@@ -1,0 +1,30 @@
+import ProjectActiveImg from '@asset/image/ProjectActive.png';
+import ProjectInactiveImg from '@asset/image/ProjectInactive.png';
+import ProjectsActiveImg from '@asset/image/ProjectsActive.png';
+import ProjectsInactiveImg from '@asset/image/ProjectsInActive.png';
+import RankingActiveImg from '@asset/image/RankingActive.png';
+import RankingInactiveImg from '@asset/image/RankingInActive.png';
+import { MenuItem } from '@type/Navbar';
+
+const MENU_ITEMS: MenuItem[] = [
+  {
+    path: '/',
+    label: '전체 프로젝트 보기',
+    activeIcon: ProjectsActiveImg,
+    inactiveIcon: ProjectsInactiveImg
+  },
+  {
+    path: '/project',
+    label: '개별 프로젝트 보기',
+    activeIcon: ProjectActiveImg,
+    inactiveIcon: ProjectInactiveImg
+  },
+  {
+    path: '/ranking',
+    label: '프로젝트 랭킹 보기',
+    activeIcon: RankingActiveImg,
+    inactiveIcon: RankingInactiveImg
+  }
+] as const;
+
+export { MENU_ITEMS };

--- a/front/src/constant/NavbarSelect.ts
+++ b/front/src/constant/NavbarSelect.ts
@@ -1,0 +1,17 @@
+const GENERATION_VALUE = {
+  ALL: 'all',
+  NINTH: '9th'
+} as const;
+
+const BOOST_CAMP_VALUE = {
+  NINTH: '부스트캠프 9기'
+} as const;
+
+const GENERATION_OPTIONS = [
+  { value: GENERATION_VALUE.ALL, label: '전체' },
+  { value: GENERATION_VALUE.NINTH, label: '9기' }
+] as const;
+
+const BOOST_CAMP_OPTION = [{ value: '9', label: BOOST_CAMP_VALUE.NINTH }] as const;
+
+export { GENERATION_OPTIONS, BOOST_CAMP_OPTION, GENERATION_VALUE, BOOST_CAMP_VALUE };

--- a/front/src/hook/useGroup.ts
+++ b/front/src/hook/useGroup.ts
@@ -1,0 +1,9 @@
+import { getGroups } from '@api/get';
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+export function useGroups(generation: string) {
+  return useSuspenseQuery({
+    queryKey: ['groups', generation],
+    queryFn: () => getGroups(generation)
+  });
+}

--- a/front/src/type/Navbar.ts
+++ b/front/src/type/Navbar.ts
@@ -1,0 +1,13 @@
+type Generation = 'all' | '9th';
+type GroupOption = {
+  value: string;
+  label: string;
+};
+type MenuItem = {
+  path: string;
+  label: string;
+  activeIcon: string;
+  inactiveIcon: string;
+};
+
+export type { Generation, GroupOption, MenuItem };


### PR DESCRIPTION
### 👀 관련 이슈
#47

### ✨ 작업한 내용
navbar와 관련해서 작업했습니다.

- [x] 타이틀 (클릭시 메인 리다이렉트)
- [x] 기수, 프로젝트 select바
- [x] 프로젝트 등록하러가기 버튼


### 🌀 PR Point
첫번 째 포인트는 상태입니다
select관련해서 기획에 맞추며 만들다보니.. 어렵더라구요
1. 메인페이지(랜딩), 랭킹 페이지에오면 첫번째 선택이 전체로 바뀝니다. (왜냐면 전체프로젝트니까)
2. 개별페이지에오면 첫번째 선택이 default로 9기로 되야합니다. (개별이니까) 
2.1 개별페이지에 오면 두번째 선택이 default로 api로 받아온 첫번째 그룹으로 되어야합니다.
이거에 맞추다 하다보니... 복잡해졌어요
구현방식은 일단 const로 첫번째,두번째 select관련된 배열을 만들어놓고 map으로 구현하는식 입니다.
상수를 만들 때 as const를 써서 완전한 readonly로 사용되도록 했습니다.

두번 째 포인트는 아토믹패턴의 단계입니다.
저번 아토믹패턴의 고민된점은, "각 단계에서 직전 하위단계만 쓸지"  vs "직전 뿐만 아니라 다른 하위단계들도 쓰기" 였다면
이번에 고민된 점은 "같은 단계의 컴포넌트를 가져다 써도 될지" 였습니다.
아토믹패턴을 쓰는 이유는 재사용과 유지보수인데.. 같은 단계의 컴포넌트를 쓰면 재사용이 될까란 생각이 들었습니다.
일단은 구현을 위해 된다고 생각하고 썼는데.. 잘 모르겠어요.. ㅠㅠ 고민고민....

### 🍰 참고사항
https://youngju-js.tistory.com/60


### 📷 스크린샷 또는 GIF
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/5543011c-a78d-40b6-930f-47672a482e1a">
