### PR TITLE
[BE] 트래픽 랭킹 TOP 5, 평균 응답시간 API 구현

### DIFF
--- a/backend/console-server/src/log/log.controller.ts
+++ b/backend/console-server/src/log/log.controller.ts
@@ -1,5 +1,7 @@
 import { Controller, Get, HttpCode, HttpStatus } from '@nestjs/common';
 import { LogService } from './log.service';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ProjectResponseDto } from '../project/dto/create-project-response.dto';
 
 @Controller('log')
 export class LogController {
@@ -13,7 +15,35 @@ export class LogController {
 
     @Get('/elapsed-time')
     @HttpCode(HttpStatus.OK)
-    async analyzeElapsedTime() {
-        return await this.logService.analyzeElapsedTime();
+    @ApiOperation({
+        summary: '기수 총 트래픽 평균 응답시간 API',
+        description: '요청받은 기수의 트래픽에 대한 평균 응답시간을 반환합니다.',
+    })
+    @ApiResponse({
+        status: 200,
+        description: '평균 응답시간이 성공적으로 반환됨.',
+        type: ProjectResponseDto,
+    })
+    async elapsedTime() {
+        return await this.logService.elapsedTime();
+    }
+
+    @Get('/traffic/rank')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: '기수 내 트래픽 랭킹 TOP 5',
+        description: '요청받은 기수의 트래픽 랭킹 TOP 5를 반환합니다.',
+    })
+    @ApiResponse({
+        status: 200,
+        description: '트래픽 랭킹 TOP 5가 정상적으로 반환됨.',
+        type: ProjectResponseDto,
+    })
+    async trafficRank() {
+        return await this.logService.trafficRank();
     }
 }
+
+// 1. 기수 내 전체 프로젝트
+// 2. 기수 내 총 트래픽
+// 4. 기수 내 응답 성공률

--- a/backend/console-server/src/log/log.service.ts
+++ b/backend/console-server/src/log/log.service.ts
@@ -13,11 +13,17 @@ export class LogService {
         return result;
     }
 
-    async analyzeElapsedTime() {
-        const result = await this.logRepository.analyzeElapsedTime();
+    async elapsedTime() {
+        const result = await this.logRepository.findAvgElapsedTime();
 
         console.log(result);
 
         return result;
+    }
+
+    async trafficRank() {
+        const result = await this.logRepository.findCountByHost();
+
+        return result.slice(0, 4);
     }
 }


### PR DESCRIPTION
- Swagger 문서화 작업 완료

### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
#69 

### ✨ 작업한 내용
- 트래픽 랭킹 TOP 5 응답 API 구현
  - host 별 로그 `count` 산출
  - SQL
```sql
SELECT host,count() as count
FROM http_log
GROUP BY host
order by count DESC;
```

- 평균 응답시간 API 구현
  - http_log 테이블의 응답시간 평균 산출
```SQL
SELECT
    avg(elapsed_time)
FROM http_log;
```

### 🌀 PR Point

### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->


### 📷 스크린샷 또는 GIF

