### PR TITLE
[BE] 개별 프로젝트 경로별 응답 속도 API 구현

### DIFF
--- a/backend/console-server/src/clickhouse/query-builder/time-series.query-builder.ts
+++ b/backend/console-server/src/clickhouse/query-builder/time-series.query-builder.ts
@@ -1,4 +1,6 @@
-import { MetricAggregationType, metricExpressions } from '../util/metric-expressions';
+import type { MetricAggregationType } from '../util/metric-expressions';
+import { metricExpressions } from '../util/metric-expressions';
+import { mapFilterCondition } from '../util/map-filter-condition';
 
 interface metric {
     name: string;
@@ -8,6 +10,7 @@ interface metric {
 export class TimeSeriesQueryBuilder {
     private query: string;
     private params: Record<string, any> = {};
+    private limitValue?: number;
 
     constructor() {
         this.query = `SELECT`;
@@ -61,10 +64,17 @@ export class TimeSeriesQueryBuilder {
 
     filter(filters: Record<string, any>): this {
         if (filters) {
-            Object.entries(filters).forEach(([key, value]) => {
-                this.query += ` AND ${key} = {${key}}`;
-                this.params[key] = value;
+            const conditions = Object.entries(filters).map(([key, value]) => {
+                const { condition, param } = mapFilterCondition(key, value);
+                this.params[key] = param;
+                return condition;
             });
+
+            if (this.query.includes('WHERE')) {
+                this.query += ` AND ${conditions.join(' AND ')}`;
+            } else {
+                this.query += ` WHERE ${conditions.join(' AND ')}`;
+            }
         }
 
         return this;
@@ -88,7 +98,16 @@ export class TimeSeriesQueryBuilder {
         return this;
     }
 
+    limit(value: number): this {
+        this.limitValue = value;
+        return this;
+    }
+
     build() {
+        if (this.limitValue) {
+            this.query += ` LIMIT ${this.limitValue}`;
+        }
+
         console.log(this.query);
 
         return { query: this.query, params: this.params };

--- a/backend/console-server/src/clickhouse/util/map-filter-condition.ts
+++ b/backend/console-server/src/clickhouse/util/map-filter-condition.ts
@@ -1,0 +1,21 @@
+type FilterValue = string | number | Date | unknown;
+
+export function mapFilterCondition(
+    key: string,
+    value: FilterValue,
+): { condition: string; param: FilterValue } {
+    let type: string;
+
+    if (typeof value === 'string') {
+        type = 'String';
+    } else if (typeof value === 'number') {
+        type = Number.isInteger(value) ? 'Int32' : 'Float64';
+    } else if (value instanceof Date) {
+        type = 'DateTime64(3)';
+    } else {
+        // Should not occur due to `FilterValue` type restriction
+        throw new Error(`Unsupported filter value type for key "${key}": ${typeof value}`);
+    }
+
+    return { condition: `${key} = {${key}:${type}}`, param: value };
+}

--- a/backend/console-server/src/log/dto/get-path-speed-rank-response.dto.ts
+++ b/backend/console-server/src/log/dto/get-path-speed-rank-response.dto.ts
@@ -1,0 +1,44 @@
+import { Exclude, Expose, Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+class PathResponseDto {
+    @ApiProperty({
+        example: '/api/v1/resource',
+        description: '사용자의 요청 경로',
+    })
+    @Expose()
+    path: string;
+
+    @ApiProperty({
+        example: 123.45,
+        description: '해당 경로의 평균 응답 소요 시간 (ms).',
+    })
+    @Expose()
+    elapsed_time: number;
+}
+
+@Exclude()
+export class GetPathSpeedRankResponseDto {
+    @ApiProperty({
+        example: 'watchducks',
+        description: '프로젝트 이름',
+    })
+    @Expose()
+    projectName: string;
+
+    @ApiProperty({
+        type: [PathResponseDto],
+        description: '프로젝트의 가장 빠른 응답 경로 배열',
+    })
+    @Expose()
+    @Type(() => PathResponseDto)
+    fastestPaths: Array<PathResponseDto>;
+
+    @ApiProperty({
+        type: [PathResponseDto],
+        description: '프로젝트의 가장 느린 응답 경로 배열',
+    })
+    @Expose()
+    @Type(() => PathResponseDto)
+    slowestPaths: Array<PathResponseDto>;
+}

--- a/backend/console-server/src/log/dto/get-path-speed-rank.dto.ts
+++ b/backend/console-server/src/log/dto/get-path-speed-rank.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class GetPathSpeedRankDto {
+    @IsNotEmpty()
+    @IsString()
+    projectName: string;
+}

--- a/backend/console-server/src/log/log.controller.ts
+++ b/backend/console-server/src/log/log.controller.ts
@@ -1,7 +1,9 @@
-import { Controller, Get, HttpCode, HttpStatus } from '@nestjs/common';
+import { Controller, Get, HttpCode, HttpStatus, Query } from '@nestjs/common';
 import { LogService } from './log.service';
 import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { ProjectResponseDto } from '../project/dto/create-project-response.dto';
+import { GetPathSpeedRankDto } from './dto/get-path-speed-rank.dto';
+import { GetPathSpeedRankResponseDto } from './dto/get-path-speed-rank-response.dto';
 
 @Controller('log')
 export class LogController {
@@ -71,5 +73,20 @@ export class LogController {
     })
     async trafficByGeneration() {
         return await this.logService.trafficByGeneration();
+    }
+
+    @Get('/response-speed/rank')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: '개별 프로젝트의 경로별 응답 속도 순위',
+        description: '개별 프로젝트의 경로별 응답 속도 중 가장 빠른/느린 3개를 반환합니다.',
+    })
+    @ApiResponse({
+        status: HttpStatus.OK,
+        description: '개별 프로젝트의 경로별 응답 속도 중 가장 빠른/느린 3개가 반환됨.',
+        type: GetPathSpeedRankResponseDto,
+    })
+    async getPathSpeedRankByProject(@Query() getPathSpeedRankDto: GetPathSpeedRankDto) {
+        return await this.logService.getPathSpeedRankByProject(getPathSpeedRankDto);
     }
 }

--- a/backend/console-server/src/log/log.module.ts
+++ b/backend/console-server/src/log/log.module.ts
@@ -3,8 +3,11 @@ import { LogService } from './log.service';
 import { LogController } from './log.controller';
 import { LogRepository } from './log.repository';
 import { Clickhouse } from '../clickhouse/clickhouse';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Project } from '../project/entities/project.entity';
 
 @Module({
+    imports: [TypeOrmModule.forFeature([Project])],
     controllers: [LogController],
     providers: [LogService, LogRepository, Clickhouse],
 })

--- a/backend/console-server/src/project/dto/create-project-response.dto.ts
+++ b/backend/console-server/src/project/dto/create-project-response.dto.ts
@@ -6,7 +6,6 @@ export class ProjectResponseDto {
     @ApiProperty({
         example: '1',
     })
-
     @Expose()
     id: number;
 }


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
#103 

### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
- TimeSeriesQueryBuilder 수정
  - filter 메소드에서 타입 미지정 오류 수정
  - WHERE가 없는 경우에도 AND만 추가되던 문제 해결
- 개별 프로젝트 경로별 응답 속도 DTO 구현
  - 요청 DTO (GetPathSpeedRankDto) 정의
  - 응답 DTO (GetPathSpeedRankResponseDto) 정의
- 개별 프로젝트 경로별 응답 속도 API 구현
  - LogModule: API 모듈 정의
  - LogController: /api/log/response-speed/rank?projectName={string} 경로에 GET API 추가 
  - LogService: 프로젝트명으로 도메인을 조회 후 로그 데이터를 가져오는 서비스 로직 구현
  - LogRepository: ClickHouse 쿼리를 통해 경로별 응답 속도를 계산하는 메서드 구현

### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
오류가 발생해 filter 메소드를 수정하고 필요상 limit 메소드를 추가하였습니다. 확인해주시면 감사하겠습니다!

### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->
테스트 케이스 작성은 아직입니다. 다른 테스트 코드 먼저 pull 받고 작업 예정입니다.

### 📷 스크린샷 또는 GIF
![image](https://github.com/user-attachments/assets/fc5d7dd3-16f2-499b-a72b-86ca9eb382f9)
