### PR TITLE
[BE] 개별 프로젝트 경로별 응답 소요 시간 api 테스트 코드 작성

### DIFF
--- a/backend/console-server/src/clickhouse/query-builder/time-series.query-builder.ts
+++ b/backend/console-server/src/clickhouse/query-builder/time-series.query-builder.ts
@@ -9,7 +9,7 @@ interface metric {
 
 export class TimeSeriesQueryBuilder {
     private query: string;
-    private params: Record<string, any> = {};
+    private params: Record<string, unknown> = {};
     private limitValue?: number;
 
     constructor() {
@@ -62,7 +62,7 @@ export class TimeSeriesQueryBuilder {
         return this;
     }
 
-    filter(filters: Record<string, any>): this {
+    filter(filters: Record<string, unknown>): this {
         if (filters) {
             const conditions = Object.entries(filters).map(([key, value]) => {
                 const { condition, param } = mapFilterCondition(key, value);

--- a/backend/console-server/src/clickhouse/util/map-filter-condition.ts
+++ b/backend/console-server/src/clickhouse/util/map-filter-condition.ts
@@ -13,9 +13,7 @@ export function mapFilterCondition(
     } else if (value instanceof Date) {
         type = 'DateTime64(3)';
     } else {
-        // Should not occur due to `FilterValue` type restriction
         throw new Error(`Unsupported filter value type for key "${key}": ${typeof value}`);
     }
-
     return { condition: `${key} = {${key}:${type}}`, param: value };
 }

--- a/backend/console-server/src/clickhouse/util/metric-expressions.ts
+++ b/backend/console-server/src/clickhouse/util/metric-expressions.ts
@@ -1,13 +1,13 @@
 type MetricFunction = (metric: string) => string;
 
 export const metricExpressions: Record<string, MetricFunction> = {
-    avg: (metric: string) => `avg(${metric}) as ${metric}`,
+    avg: (metric: string) => `avg(${metric}) as avg_${metric}`,
     count: () => `count() as count`,
-    sum: (metric: string) => `sum(${metric}) as ${metric}`,
-    min: (metric: string) => `min(${metric}) as ${metric}`,
-    max: (metric: string) => `max(${metric}) as ${metric}`,
-    p95: (metric: string) => `quantile(0.95)(${metric}) as ${metric}`,
-    p99: (metric: string) => `quantile(0.99)(${metric}) as ${metric}`,
+    sum: (metric: string) => `sum(${metric}) as sum_${metric}`,
+    min: (metric: string) => `min(${metric}) as min_${metric}`,
+    max: (metric: string) => `max(${metric}) as max_${metric}`,
+    p95: (metric: string) => `quantile(0.95)(${metric}) as p95_${metric}`,
+    p99: (metric: string) => `quantile(0.99)(${metric}) as p99_${metric}`,
     rate: (metric: string) => `(sum(${metric}) / count(*)) * 100 as ${metric}_rate`,
 };
 

--- a/backend/console-server/src/log/dto/get-path-speed-rank-response.dto.ts
+++ b/backend/console-server/src/log/dto/get-path-speed-rank-response.dto.ts
@@ -14,7 +14,7 @@ class PathResponseDto {
         description: '해당 경로의 평균 응답 소요 시간 (ms).',
     })
     @Expose()
-    elapsed_time: number;
+    avg_elapsed_time: number;
 }
 
 @Exclude()

--- a/backend/console-server/src/log/log.contorller.spec.ts
+++ b/backend/console-server/src/log/log.contorller.spec.ts
@@ -19,6 +19,7 @@ describe('LogController 테스트', () => {
         trafficRank: jest.fn(),
         responseSuccessRate: jest.fn(),
         trafficByGeneration: jest.fn(),
+        getPathSpeedRankByProject: jest.fn(),
     };
 
     beforeEach(async () => {
@@ -146,6 +147,52 @@ describe('LogController 테스트', () => {
             expect(result).toHaveProperty('status', HttpStatus.OK);
             expect(result).toHaveProperty('data.total_traffic');
             expect(service.trafficByGeneration).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('getPathSpeedRankByProject()는 ', () => {
+        const mockRequestDto = {
+            projectName: 'example-project',
+        };
+
+        const mockResponseDto = {
+            projectName: 'example-project',
+            fastestPaths: [
+                { path: '/api/v1/resource', avg_elapsed_time: 123.45 },
+                { path: '/api/v1/users', avg_elapsed_time: 145.67 },
+                { path: '/api/v1/orders', avg_elapsed_time: 150.89 },
+            ],
+            slowestPaths: [
+                { path: '/api/v1/reports', avg_elapsed_time: 345.67 },
+                { path: '/api/v1/logs', avg_elapsed_time: 400.23 },
+                { path: '/api/v1/stats', avg_elapsed_time: 450.56 },
+            ],
+        };
+
+        it('프로젝트의 경로별 응답 속도 순위를 반환해야 한다', async () => {
+            mockLogService.getPathSpeedRankByProject.mockResolvedValue(mockResponseDto);
+
+            const result = await controller.getPathSpeedRankByProject(mockRequestDto);
+
+            expect(result).toEqual(mockResponseDto);
+            expect(service.getPathSpeedRankByProject).toHaveBeenCalledWith(mockRequestDto);
+            expect(service.getPathSpeedRankByProject).toHaveBeenCalledTimes(1);
+
+            expect(result).toHaveProperty('projectName', mockRequestDto.projectName);
+            expect(result.fastestPaths).toHaveLength(3);
+            expect(result.slowestPaths).toHaveLength(3);
+        });
+
+        it('서비스 에러 시 예외를 throw 해야 한다', async () => {
+            const error = new Error('Database error');
+            mockLogService.getPathSpeedRankByProject.mockRejectedValue(error);
+
+            await expect(controller.getPathSpeedRankByProject(mockRequestDto)).rejects.toThrow(
+                error,
+            );
+
+            expect(service.getPathSpeedRankByProject).toHaveBeenCalledWith(mockRequestDto);
+            expect(service.getPathSpeedRankByProject).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/backend/console-server/src/log/log.controller.ts
+++ b/backend/console-server/src/log/log.controller.ts
@@ -75,7 +75,7 @@ export class LogController {
         return await this.logService.trafficByGeneration();
     }
 
-    @Get('/response-speed/rank')
+    @Get('/elapsed-time/path-rank')
     @HttpCode(HttpStatus.OK)
     @ApiOperation({
         summary: '개별 프로젝트의 경로별 응답 속도 순위',

--- a/backend/console-server/src/log/log.repository.spec.ts
+++ b/backend/console-server/src/log/log.repository.spec.ts
@@ -141,4 +141,56 @@ describe('LogRepository 테스트', () => {
             );
         });
     });
+
+    describe('getPathSpeedRankByProject()는 ', () => {
+        const domain = 'example.com';
+        const mockFastestPaths = [
+            { path: '/api/v1/resource', avg_elapsed_time: 123.45 },
+            { path: '/api/v1/users', avg_elapsed_time: 145.67 },
+            { path: '/api/v1/orders', avg_elapsed_time: 150.89 },
+        ];
+        const mockSlowestPaths = [
+            { path: '/api/v1/reports', avg_elapsed_time: 345.67 },
+            { path: '/api/v1/logs', avg_elapsed_time: 400.23 },
+            { path: '/api/v1/stats', avg_elapsed_time: 450.56 },
+        ];
+
+        it('도메인을 기준으로 Top 3 fastest 경로와 slowest 경로를 반환해야 한다.', async () => {
+            mockClickhouse.query
+                .mockResolvedValueOnce(mockFastestPaths)
+                .mockResolvedValueOnce(mockSlowestPaths);
+
+            const result = await repository.getPathSpeedRankByProject(domain);
+
+            expect(result).toEqual({
+                fastestPaths: mockFastestPaths,
+                slowestPaths: mockSlowestPaths,
+            });
+
+            expect(clickhouse.query).toHaveBeenCalledTimes(2);
+            expect(clickhouse.query).toHaveBeenNthCalledWith(
+                1,
+                expect.stringMatching(
+                    /SELECT\s+avg\(elapsed_time\) as avg_elapsed_time,\s+path\s+FROM http_log\s+WHERE host = \{host:String}\s+GROUP BY path\s+ORDER BY avg_elapsed_time\s+LIMIT 3/,
+                ),
+                expect.objectContaining({ host: domain }),
+            );
+            expect(clickhouse.query).toHaveBeenNthCalledWith(
+                2,
+                expect.stringMatching(
+                    /SELECT\s+avg\(elapsed_time\) as avg_elapsed_time,\s+path\s+FROM http_log\s+WHERE host = \{host:String}\s+GROUP BY path\s+ORDER BY avg_elapsed_time DESC\s+LIMIT 3/,
+                ),
+                expect.objectContaining({ host: domain }),
+            );
+        });
+
+        it('클릭하우스 에러 발생 시 예외를 throw 해야 한다.', async () => {
+            const error = new Error('Clickhouse query failed');
+            mockClickhouse.query.mockRejectedValue(error);
+
+            await expect(repository.getPathSpeedRankByProject(domain)).rejects.toThrow(
+                'Clickhouse query failed',
+            );
+        });
+    });
 });

--- a/backend/console-server/src/log/log.repository.ts
+++ b/backend/console-server/src/log/log.repository.ts
@@ -87,7 +87,7 @@ export class LogRepository {
             .from('http_log')
             .filter({ host: domain })
             .groupBy(['path'])
-            .orderBy(['elapsed_time'], false)
+            .orderBy(['avg_elapsed_time'], false)
             .limit(3)
             .build();
 
@@ -96,7 +96,7 @@ export class LogRepository {
             .from('http_log')
             .filter({ host: domain })
             .groupBy(['path'])
-            .orderBy(['elapsed_time'], true)
+            .orderBy(['avg_elapsed_time'], true)
             .limit(3)
             .build();
 


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
- #103

### ✨ 작업한 내용
1. 컨트롤러 테스트 코드 작성
- [x] LogController의 주요 메서드 (httpLog, elapsedTime, trafficRank, responseSuccessRate, trafficByGeneration, getPathSpeedRankByProject)에 대한 테스트 코드 작성.
- [x] Mock Service를 활용하여 Controller의 입력과 출력만 검증.
2. 서비스 테스트 코드 작성
- [x] LogService의 주요 메서드 (httpLog, elapsedTime, trafficRank, responseSuccessRate, trafficByGeneration, getPathSpeedRankByProject)에 대한 테스트 코드 작성.
- [x] Mock Repository를 활용하여 Service 로직의 결과를 검증.
3. 레포지토리 테스트 코드 작성
- [x] LogRepository의 주요 메서드 (findHttpLog, findAvgElapsedTime, findCountByHost, findResponseSuccessRate, findTrafficByGeneration, getPathSpeedRankByProject)에 대한 테스트 코드 작성.
- [x] Mock Clickhouse를 사용하여 SQL 실행 결과 및 파라미터를 검증.
- [x] getPathSpeedRankByProject에서 쿼리 실행 및 반환 데이터 검증.

### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
- Repository에서 사용하는 쿼리빌더의 결과를 테스트하는 것이 적절할까요?

### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->
- 테스트용 모듈에 Mock ProjectRepository도 주입하였습니다. 

### 📷 스크린샷 또는 GIF
- LogController 테스트
   getPathSpeedRankByProject()는 
      ✓ 프로젝트의 경로별 응답 속도 순위를 반환해야 한다 (1 ms)
      ✓ 서비스 에러 시 예외를 throw 해야 한다 (1 ms)
- LogService 테스트
   getPathSpeedRankByProject()는 
      ✓ 프로젝트명을 기준으로 도메인을 조회한 후 경로별 응답 속도 순위를 반환해야 한다 (2 ms)
      ✓ 존재하지 않는 프로젝트명을 조회할 경우 NotFoundException을 던져야 한다 (2 ms)
      ✓ 로그 레포지토리 호출 중 에러가 발생할 경우 예외를 던져야 한다
- LogRepository 테스트
   getPathSpeedRankByProject()는 
      ✓ 도메인을 기준으로 Top 3 fastest 경로와 slowest 경로를 반환해야 한다. (5 ms)
      ✓ 클릭하우스 에러 발생 시 예외를 throw 해야 한다. (5 ms)
- 커버리지
  | File                | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s |
  |---------------------|---------|----------|---------|---------|-------------------|
  | log.controller.ts   |     100 |      100 |     100 |     100 |                   |
  | log.repository.ts   |     100 |      100 |     100 |     100 |                   |
  | log.service.ts      |     100 |      100 |     100 |     100 |                   |

