### PR TITLE
[BE] 로그 데이터 관련 API DTO 수정 및 param 추가

### DIFF
--- a/backend/console-server/src/log/dto/get-success-rate-response.dto.ts
+++ b/backend/console-server/src/log/dto/get-success-rate-response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+
+export class GetSuccessRateResponseDto {
+    @ApiProperty({
+        example: 95.5,
+        description: '응답 성공률 (%)',
+        type: Number,
+    })
+    @Expose()
+    success_rate: number;
+}

--- a/backend/console-server/src/log/dto/get-success-rate.dto.ts
+++ b/backend/console-server/src/log/dto/get-success-rate.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsNumber } from 'class-validator';
+
+export class GetSuccessRateDto {
+    @IsNumber()
+    @Type(() => Number)
+    @ApiProperty({
+        description: '기수',
+        example: 5,
+        required: true,
+    })
+    generation: number;
+}

--- a/backend/console-server/src/log/dto/get-traffic-by-generation-response.dto.ts
+++ b/backend/console-server/src/log/dto/get-traffic-by-generation-response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+
+export class GetTrafficByGenerationResponseDto {
+    @ApiProperty({
+        example: 15,
+        description: '기수 별 트래픽 수',
+        type: Number,
+    })
+    @Expose()
+    count: number;
+}

--- a/backend/console-server/src/log/dto/get-traffic-by-generation.dto.ts
+++ b/backend/console-server/src/log/dto/get-traffic-by-generation.dto.ts
@@ -1,0 +1,14 @@
+import { IsNumber } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetTrafficByGenerationDto {
+    @IsNumber()
+    @Type(() => Number)
+    @ApiProperty({
+        description: '기수',
+        example: 5,
+        required: true,
+    })
+    generation: number;
+}

--- a/backend/console-server/src/log/log.contorller.spec.ts
+++ b/backend/console-server/src/log/log.contorller.spec.ts
@@ -18,7 +18,7 @@ describe('LogController 테스트', () => {
         elapsedTime: jest.fn(),
         trafficRank: jest.fn(),
         getResponseSuccessRate: jest.fn(),
-        trafficByGeneration: jest.fn(),
+        getTrafficByGeneration: jest.fn(),
         getPathSpeedRankByProject: jest.fn(),
         getTrafficByProject: jest.fn(),
     };
@@ -131,20 +131,18 @@ describe('LogController 테스트', () => {
     });
 
     describe('trafficByGeneration()는 ', () => {
-        const mockResult = {
-            status: HttpStatus.OK,
-            data: { total_traffic: 15000 },
-        };
+        it('기수별 트래픽 총량을 올바르게 반환해야 한다', async () => {
+            const mockTrafficByGenerationDto = { generation: 9 };
+            const mockResponse = { count: 1000 };
 
-        it('기수별 총 트래픽을 ProjectResponseDto 형식으로 반환해야 한다', async () => {
-            mockLogService.trafficByGeneration.mockResolvedValue(mockResult);
+            mockLogService.getTrafficByGeneration.mockResolvedValue(mockResponse);
 
-            const result = await controller.trafficByGeneration();
+            const result = await controller.getTrafficByGeneration(mockTrafficByGenerationDto);
 
-            expect(result).toEqual(mockResult);
-            expect(result).toHaveProperty('status', HttpStatus.OK);
-            expect(result).toHaveProperty('data.total_traffic');
-            expect(service.trafficByGeneration).toHaveBeenCalledTimes(1);
+            expect(result).toEqual(mockResponse);
+            expect(result).toHaveProperty('count', 1000);
+            expect(service.getTrafficByGeneration).toHaveBeenCalledWith(mockTrafficByGenerationDto);
+            expect(service.getTrafficByGeneration).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/backend/console-server/src/log/log.contorller.spec.ts
+++ b/backend/console-server/src/log/log.contorller.spec.ts
@@ -17,7 +17,7 @@ describe('LogController 테스트', () => {
         httpLog: jest.fn(),
         elapsedTime: jest.fn(),
         trafficRank: jest.fn(),
-        responseSuccessRate: jest.fn(),
+        getResponseSuccessRate: jest.fn(),
         trafficByGeneration: jest.fn(),
         getPathSpeedRankByProject: jest.fn(),
         getTrafficByProject: jest.fn(),
@@ -115,21 +115,18 @@ describe('LogController 테스트', () => {
         });
     });
 
-    describe('responseSuccessRate()는 ', () => {
-        const mockResult = {
-            status: HttpStatus.OK,
-            data: { success_rate: 98.5 },
-        };
+    describe('getResponseSuccessRate()는 ', () => {
+        const mockSuccessRateDto = { generation: 5 };
+        const mockServiceResponse = { success_rate: 98.5 };
 
-        it('응답 성공률을 ProjectResponseDto 형식으로 반환해야 한다', async () => {
-            mockLogService.responseSuccessRate.mockResolvedValue(mockResult);
+        it('응답 성공률을 반환해야 한다', async () => {
+            mockLogService.getResponseSuccessRate.mockResolvedValue(mockServiceResponse);
 
-            const result = await controller.responseSuccessRate();
+            const result = await controller.getResponseSuccessRate(mockSuccessRateDto);
 
-            expect(result).toEqual(mockResult);
-            expect(result).toHaveProperty('status', HttpStatus.OK);
-            expect(result).toHaveProperty('data.success_rate');
-            expect(service.responseSuccessRate).toHaveBeenCalledTimes(1);
+            expect(result).toEqual({ success_rate: 98.5 });
+            expect(service.getResponseSuccessRate).toHaveBeenCalledWith(mockSuccessRateDto);
+            expect(service.getResponseSuccessRate).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/backend/console-server/src/log/log.controller.ts
+++ b/backend/console-server/src/log/log.controller.ts
@@ -8,6 +8,7 @@ import { GetTrafficByProjectResponseDto } from './dto/get-traffic-by-project-res
 import { GetTrafficByProjectDto } from './dto/get-traffic-by-project.dto';
 import { GetSuccessRateResponseDto } from './dto/get-success-rate-response.dto';
 import { GetSuccessRateDto } from './dto/get-success-rate.dto';
+import { GetTrafficByGenerationDto } from './dto/get-traffic-by-generation.dto';
 
 @Controller('log')
 export class LogController {
@@ -83,15 +84,15 @@ export class LogController {
     @HttpCode(HttpStatus.OK)
     @ApiOperation({
         summary: '기수 내 총 트래픽',
-        description: '요청받은 기수의 기수 내 총 트래픽를 반환합니다.',
+        description: ' 요청받은 기수의 기수 내 총 트래픽를 반환합니다.',
     })
     @ApiResponse({
         status: 200,
         description: '기수 내 총 트래픽가 정상적으로 반환됨.',
-        type: ProjectResponseDto,
+        type: GetTrafficByProjectResponseDto,
     })
-    async trafficByGeneration() {
-        return await this.logService.trafficByGeneration();
+    async getTrafficByGeneration(@Query() getTrafficByGenerationDto: GetTrafficByGenerationDto) {
+        return await this.logService.getTrafficByGeneration(getTrafficByGenerationDto);
     }
 
     @Get('/elapsed-time/path-rank')

--- a/backend/console-server/src/log/log.controller.ts
+++ b/backend/console-server/src/log/log.controller.ts
@@ -50,7 +50,7 @@ export class LogController {
         return await this.logService.trafficRank();
     }
 
-    @Get('/response-rate')
+    @Get('/success-rate')
     @HttpCode(HttpStatus.OK)
     @ApiOperation({
         summary: '기수 내 응답 성공률',
@@ -63,6 +63,14 @@ export class LogController {
     })
     async getResponseSuccessRate(getSuccessRateDto: GetSuccessRateDto) {
         return await this.logService.getResponseSuccessRate(getSuccessRateDto);
+    }
+
+    @Get('/success-rate/project')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({})
+    @ApiResponse({})
+    async getResponseSuccessRateByProject(){
+        // return await this.logService.getResponseSuccessRate();
     }
 
     @Get('/traffic/project')

--- a/backend/console-server/src/log/log.controller.ts
+++ b/backend/console-server/src/log/log.controller.ts
@@ -6,6 +6,8 @@ import { GetPathSpeedRankDto } from './dto/get-path-speed-rank.dto';
 import { GetPathSpeedRankResponseDto } from './dto/get-path-speed-rank-response.dto';
 import { GetTrafficByProjectResponseDto } from './dto/get-traffic-by-project-response.dto';
 import { GetTrafficByProjectDto } from './dto/get-traffic-by-project.dto';
+import { GetSuccessRateResponseDto } from './dto/get-success-rate-response.dto';
+import { GetSuccessRateDto } from './dto/get-success-rate.dto';
 
 @Controller('log')
 export class LogController {
@@ -56,10 +58,10 @@ export class LogController {
     @ApiResponse({
         status: 200,
         description: '기수 내 응답 성공률이 성공적으로 반환됨.',
-        type: ProjectResponseDto,
+        type: GetSuccessRateResponseDto,
     })
-    async responseSuccessRate() {
-        return await this.logService.responseSuccessRate();
+    async getResponseSuccessRate(getSuccessRateDto: GetSuccessRateDto) {
+        return await this.logService.getResponseSuccessRate(getSuccessRateDto);
     }
 
     @Get('/traffic/project')

--- a/backend/console-server/src/log/log.repository.spec.ts
+++ b/backend/console-server/src/log/log.repository.spec.ts
@@ -107,14 +107,13 @@ describe('LogRepository 테스트', () => {
     describe('findResponseSuccessRate()는 ', () => {
         it('성공률을 올바르게 계산할 수 있어야 한다.', async () => {
             const mockQueryResult = [{ is_error_rate: 1.5 }];
-            mockClickhouse.query.mockResolvedValue(mockQueryResult);
+            (clickhouse.query as jest.Mock).mockResolvedValue(mockQueryResult);
 
             const result = await repository.findResponseSuccessRate();
 
             expect(result).toEqual({ success_rate: 98.5 });
             expect(clickhouse.query).toHaveBeenCalledWith(
-                expect.stringMatching(/SELECT.*sum\(is_error\).*count\(\*\).*as is_error_rate/s),
-                expect.any(Object),
+                "SELECT (sum(is_error) / count(*)) * 100 as is_error_rate\n    FROM http_log"
             );
         });
 

--- a/backend/console-server/src/log/log.repository.spec.ts
+++ b/backend/console-server/src/log/log.repository.spec.ts
@@ -113,7 +113,7 @@ describe('LogRepository 테스트', () => {
 
             expect(result).toEqual({ success_rate: 98.5 });
             expect(clickhouse.query).toHaveBeenCalledWith(
-                "SELECT (sum(is_error) / count(*)) * 100 as is_error_rate\n    FROM http_log"
+                'SELECT (sum(is_error) / count(*)) * 100 as is_error_rate\n    FROM http_log',
             );
         });
 
@@ -133,7 +133,7 @@ describe('LogRepository 테스트', () => {
 
             const result = await repository.findTrafficByGeneration();
 
-            expect(result).toEqual(mockResult[0]);
+            expect(result).toEqual(mockResult);
             expect(clickhouse.query).toHaveBeenCalledWith(
                 expect.stringMatching(/SELECT.*count\(\).*as count/s),
                 expect.any(Object),

--- a/backend/console-server/src/log/log.repository.ts
+++ b/backend/console-server/src/log/log.repository.ts
@@ -78,7 +78,7 @@ export class LogRepository {
             .build();
 
         const result = await this.clickhouse.query(query, params);
-        return result[0];
+        return [{ count: ((result as unknown[])[0] as { count: number }).count }];
     }
 
     async getPathSpeedRankByProject(domain: string) {

--- a/backend/console-server/src/log/log.repository.ts
+++ b/backend/console-server/src/log/log.repository.ts
@@ -50,7 +50,7 @@ export class LogRepository {
     }
 
     async findResponseSuccessRate() {
-        const { query, params } = new TimeSeriesQueryBuilder()
+        const { query } = new TimeSeriesQueryBuilder()
             .metrics([
                 {
                     name: 'is_error',
@@ -60,7 +60,7 @@ export class LogRepository {
             .from('http_log')
             .build();
 
-        const result = await this.clickhouse.query(query, params);
+        const result = await this.clickhouse.query(query);
         return {
             success_rate: 100 - (result as Array<{ is_error_rate: number }>)[0].is_error_rate,
         };

--- a/backend/console-server/src/log/log.service.spec.ts
+++ b/backend/console-server/src/log/log.service.spec.ts
@@ -118,12 +118,14 @@ describe('LogService 테스트', () => {
 
     describe('responseSuccessRate()는 ', () => {
         it('응답 성공률을 반환할 수 있어야 한다.', async () => {
-            const mockRate = { success_rate: 98.5 };
-            mockLogRepository.findResponseSuccessRate.mockResolvedValue(mockRate);
+            const mockSuccessRateDto = { generation: 5 };
+            const mockRepositoryResponse = { success_rate: 98.5 };
+            mockLogRepository.findResponseSuccessRate.mockResolvedValue(mockRepositoryResponse);
+            const expectedResult = { success_rate: 98.5 };
 
-            const result = await service.responseSuccessRate();
+            const result = await service.getResponseSuccessRate(mockSuccessRateDto);
 
-            expect(result).toEqual(mockRate);
+            expect(result).toEqual(expectedResult);
             expect(repository.findResponseSuccessRate).toHaveBeenCalled();
         });
     });

--- a/backend/console-server/src/log/log.service.spec.ts
+++ b/backend/console-server/src/log/log.service.spec.ts
@@ -5,6 +5,8 @@ import { LogRepository } from './log.repository';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Project } from '../project/entities/project.entity';
 import { NotFoundException } from '@nestjs/common';
+import type { GetTrafficByGenerationResponseDto } from './dto/get-traffic-by-generation-response.dto';
+import { GetTrafficByGenerationDto } from './dto/get-traffic-by-generation.dto';
 
 describe('LogService 테스트', () => {
     let service: LogService;
@@ -118,7 +120,7 @@ describe('LogService 테스트', () => {
 
     describe('responseSuccessRate()는 ', () => {
         it('응답 성공률을 반환할 수 있어야 한다.', async () => {
-            const mockSuccessRateDto = { generation: 5 };
+            const mockSuccessRateDto = { generation: 9 };
             const mockRepositoryResponse = { success_rate: 98.5 };
             mockLogRepository.findResponseSuccessRate.mockResolvedValue(mockRepositoryResponse);
             const expectedResult = { success_rate: 98.5 };
@@ -131,18 +133,27 @@ describe('LogService 테스트', () => {
     });
 
     describe('trafficByGeneration()는 ', () => {
-        it('기수별 트래픽을 올바르게 반환할 수 있어야 한다.', async () => {
+        it('기수별 트래픽의 총합을 올바르게 반환할 수 있어야 한다.', async () => {
             const mockStats = [
                 { generation: '10s', count: 500 },
                 { generation: '20s', count: 300 },
                 { generation: '30s', count: 200 },
             ];
-            mockLogRepository.findTrafficByGeneration.mockResolvedValue(mockStats);
+            const expectedTotalCount = mockStats.reduce((sum, stat) => sum + stat.count, 0);
+            const dto = new GetTrafficByGenerationDto();
+            dto.generation = 9;
 
-            const result = await service.trafficByGeneration();
+            const mockRepositoryResponse = [{ count: expectedTotalCount }];
+            const expectedResponse: GetTrafficByGenerationResponseDto = {
+                count: expectedTotalCount,
+            };
+            mockLogRepository.findTrafficByGeneration.mockResolvedValue(mockRepositoryResponse);
 
-            expect(result).toEqual(mockStats);
-            expect(repository.findTrafficByGeneration).toHaveBeenCalled();
+            const result = await service.getTrafficByGeneration(dto);
+
+            expect(result).toEqual(expectedResponse);
+            expect(mockLogRepository.findTrafficByGeneration).toHaveBeenCalledTimes(1);
+            expect(mockLogRepository.findTrafficByGeneration).toHaveBeenCalled();
         });
     });
 

--- a/backend/console-server/src/log/log.service.ts
+++ b/backend/console-server/src/log/log.service.ts
@@ -45,17 +45,13 @@ export class LogService {
     async getResponseSuccessRate(_getSuccessRateDto: GetSuccessRateDto) {
         const result = await this.logRepository.findResponseSuccessRate();
 
-        return plainToInstance(GetSuccessRateResponseDto, {
-            success_rate: result.success_rate,
-        });
+        return plainToInstance(GetSuccessRateResponseDto, result);
     }
 
     async getTrafficByGeneration(_getTrafficByGenerationDto: GetTrafficByGenerationDto) {
         const result = await this.logRepository.findTrafficByGeneration();
 
-        return plainToInstance(GetTrafficByGenerationDto, {
-            count: result[0].count,
-        });
+        return plainToInstance(GetTrafficByGenerationDto, result[0]);
     }
 
     async getPathSpeedRankByProject(getPathSpeedRankDto: GetPathSpeedRankDto) {

--- a/backend/console-server/src/log/log.service.ts
+++ b/backend/console-server/src/log/log.service.ts
@@ -8,6 +8,8 @@ import { GetPathSpeedRankDto } from './dto/get-path-speed-rank.dto';
 import { GetPathSpeedRankResponseDto } from './dto/get-path-speed-rank-response.dto';
 import { GetTrafficByProjectDto } from './dto/get-traffic-by-project.dto';
 import { GetTrafficByProjectResponseDto } from './dto/get-traffic-by-project-response.dto';
+import { GetSuccessRateResponseDto } from './dto/get-success-rate-response.dto';
+import { GetSuccessRateDto } from './dto/get-success-rate.dto';
 
 @Injectable()
 export class LogService {
@@ -39,10 +41,12 @@ export class LogService {
         return result.slice(0, 5);
     }
 
-    async responseSuccessRate() {
+    async getResponseSuccessRate(_getSuccessRateDto: GetSuccessRateDto) {
         const result = await this.logRepository.findResponseSuccessRate();
 
-        return result;
+        return plainToInstance(GetSuccessRateResponseDto, {
+            success_rate: result.success_rate,
+        });
     }
 
     async trafficByGeneration() {

--- a/backend/console-server/src/log/log.service.ts
+++ b/backend/console-server/src/log/log.service.ts
@@ -10,6 +10,7 @@ import { GetTrafficByProjectDto } from './dto/get-traffic-by-project.dto';
 import { GetTrafficByProjectResponseDto } from './dto/get-traffic-by-project-response.dto';
 import { GetSuccessRateResponseDto } from './dto/get-success-rate-response.dto';
 import { GetSuccessRateDto } from './dto/get-success-rate.dto';
+import { GetTrafficByGenerationDto } from './dto/get-traffic-by-generation.dto';
 
 @Injectable()
 export class LogService {
@@ -49,10 +50,12 @@ export class LogService {
         });
     }
 
-    async trafficByGeneration() {
+    async getTrafficByGeneration(_getTrafficByGenerationDto: GetTrafficByGenerationDto) {
         const result = await this.logRepository.findTrafficByGeneration();
 
-        return result;
+        return plainToInstance(GetTrafficByGenerationDto, {
+            count: result[0].count,
+        });
     }
 
     async getPathSpeedRankByProject(getPathSpeedRankDto: GetPathSpeedRankDto) {


### PR DESCRIPTION
### 👀 관련 이슈
#110 

### ✨ 작업한 내용
 - 기수별 평균 응답 성공률 api 수정
    - get-success-rate-response.dto 생성
    - get-success-rate.dto 생성
   - generation 값을 받도록 변경
 - 기수별 평균 응답 성공률 테스트 코드 수정
 - 기수별 트래픽 api 수정
   - get-traffic-by-generation.dto 적용
   - get-traffic-by-generation-response.dto 적용
   - generation 값을 받도록 변경
-  기수별 트래픽 테스트 코드 수정


### 🌀 PR Point
- 기수별 traffic을 가져오는 api에서 repository 단에 타입 선언을 써서 리턴해주는데, 더 나은 방법이 있다면 조언 부탁드립니당!
- 기수별 평균 응답 성공률 가져오는 부분에서 경로에서 log/response-rate를 사용하고 있는데, 단어가 조금 어색한 느낌이 있어서 괜찮은지 한 번 피드백 부탁드려요!

### 📷 스크린샷 또는 GIF
![image](https://github.com/user-attachments/assets/3cd4693b-e18d-4824-8e0d-f465e37111fe)
![image](https://github.com/user-attachments/assets/66f44c52-02ea-41f2-8056-7bd7c72a775d)


