### PR TITLE
[BE] 개별 프로젝트 응답 성공률 기능 구현

### DIFF
--- a/backend/console-server/src/log/dto/get-success-rate-by-project-response.dto.ts
+++ b/backend/console-server/src/log/dto/get-success-rate-by-project-response.dto.ts
@@ -1,0 +1,18 @@
+import { Expose, Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetSuccessRateByProjectResponseDTO {
+    @ApiProperty({
+        description: '프로젝트의 이름',
+        example: 'watchducks',
+    })
+    @Expose()
+    projectName: string;
+    @ApiProperty({
+        description: '프로젝트의 응답 성공률',
+        example: 85.5,
+    })
+    @Expose()
+    @Type(() => Number)
+    success_rate: number;
+}

--- a/backend/console-server/src/log/dto/get-success-rate-by-project.dto.ts
+++ b/backend/console-server/src/log/dto/get-success-rate-by-project.dto.ts
@@ -1,0 +1,12 @@
+import { IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetSuccessRateByProjectDto {
+    @IsString()
+    @ApiProperty({
+        description: '프로젝트 이름',
+        example: 'watchducks',
+        required: true,
+    })
+    projectName: string;
+}

--- a/backend/console-server/src/log/dto/get-success-rate-response.dto.ts
+++ b/backend/console-server/src/log/dto/get-success-rate-response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+
+export class GetSuccessRateResponseDto {
+    @ApiProperty({
+        example: 95.5,
+        description: '응답 성공률 (%)',
+        type: Number,
+    })
+    @Expose()
+    success_rate: number;
+}

--- a/backend/console-server/src/log/dto/get-success-rate.dto.ts
+++ b/backend/console-server/src/log/dto/get-success-rate.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsNumber } from 'class-validator';
+
+export class GetSuccessRateDto {
+    @IsNumber()
+    @Type(() => Number)
+    @ApiProperty({
+        description: '기수',
+        example: 5,
+        required: true,
+    })
+    generation: number;
+}

--- a/backend/console-server/src/log/dto/get-traffic-by-generation-response.dto.ts
+++ b/backend/console-server/src/log/dto/get-traffic-by-generation-response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+
+export class GetTrafficByGenerationResponseDto {
+    @ApiProperty({
+        example: 15,
+        description: '기수 별 트래픽 수',
+        type: Number,
+    })
+    @Expose()
+    count: number;
+}

--- a/backend/console-server/src/log/dto/get-traffic-by-generation.dto.ts
+++ b/backend/console-server/src/log/dto/get-traffic-by-generation.dto.ts
@@ -1,0 +1,14 @@
+import { IsNumber } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetTrafficByGenerationDto {
+    @IsNumber()
+    @Type(() => Number)
+    @ApiProperty({
+        description: '기수',
+        example: 5,
+        required: true,
+    })
+    generation: number;
+}

--- a/backend/console-server/src/log/log.contorller.spec.ts
+++ b/backend/console-server/src/log/log.contorller.spec.ts
@@ -18,7 +18,7 @@ describe('LogController 테스트', () => {
         elapsedTime: jest.fn(),
         trafficRank: jest.fn(),
         getResponseSuccessRate: jest.fn(),
-        trafficByGeneration: jest.fn(),
+        getTrafficByGeneration: jest.fn(),
         getPathSpeedRankByProject: jest.fn(),
         getTrafficByProject: jest.fn(),
     };
@@ -131,20 +131,18 @@ describe('LogController 테스트', () => {
     });
 
     describe('trafficByGeneration()는 ', () => {
-        const mockResult = {
-            status: HttpStatus.OK,
-            data: { total_traffic: 15000 },
-        };
+        it('기수별 트래픽 총량을 올바르게 반환해야 한다', async () => {
+            const mockTrafficByGenerationDto = { generation: 9 };
+            const mockResponse = { count: 1000 };
 
-        it('기수별 총 트래픽을 ProjectResponseDto 형식으로 반환해야 한다', async () => {
-            mockLogService.trafficByGeneration.mockResolvedValue(mockResult);
+            mockLogService.getTrafficByGeneration.mockResolvedValue(mockResponse);
 
-            const result = await controller.trafficByGeneration();
+            const result = await controller.getTrafficByGeneration(mockTrafficByGenerationDto);
 
-            expect(result).toEqual(mockResult);
-            expect(result).toHaveProperty('status', HttpStatus.OK);
-            expect(result).toHaveProperty('data.total_traffic');
-            expect(service.trafficByGeneration).toHaveBeenCalledTimes(1);
+            expect(result).toEqual(mockResponse);
+            expect(result).toHaveProperty('count', 1000);
+            expect(service.getTrafficByGeneration).toHaveBeenCalledWith(mockTrafficByGenerationDto);
+            expect(service.getTrafficByGeneration).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/backend/console-server/src/log/log.contorller.spec.ts
+++ b/backend/console-server/src/log/log.contorller.spec.ts
@@ -17,7 +17,7 @@ describe('LogController 테스트', () => {
         httpLog: jest.fn(),
         elapsedTime: jest.fn(),
         trafficRank: jest.fn(),
-        responseSuccessRate: jest.fn(),
+        getResponseSuccessRate: jest.fn(),
         trafficByGeneration: jest.fn(),
         getPathSpeedRankByProject: jest.fn(),
         getTrafficByProject: jest.fn(),
@@ -115,21 +115,18 @@ describe('LogController 테스트', () => {
         });
     });
 
-    describe('responseSuccessRate()는 ', () => {
-        const mockResult = {
-            status: HttpStatus.OK,
-            data: { success_rate: 98.5 },
-        };
+    describe('getResponseSuccessRate()는 ', () => {
+        const mockSuccessRateDto = { generation: 5 };
+        const mockServiceResponse = { success_rate: 98.5 };
 
-        it('응답 성공률을 ProjectResponseDto 형식으로 반환해야 한다', async () => {
-            mockLogService.responseSuccessRate.mockResolvedValue(mockResult);
+        it('응답 성공률을 반환해야 한다', async () => {
+            mockLogService.getResponseSuccessRate.mockResolvedValue(mockServiceResponse);
 
-            const result = await controller.responseSuccessRate();
+            const result = await controller.getResponseSuccessRate(mockSuccessRateDto);
 
-            expect(result).toEqual(mockResult);
-            expect(result).toHaveProperty('status', HttpStatus.OK);
-            expect(result).toHaveProperty('data.success_rate');
-            expect(service.responseSuccessRate).toHaveBeenCalledTimes(1);
+            expect(result).toEqual({ success_rate: 98.5 });
+            expect(service.getResponseSuccessRate).toHaveBeenCalledWith(mockSuccessRateDto);
+            expect(service.getResponseSuccessRate).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/backend/console-server/src/log/log.contorller.spec.ts
+++ b/backend/console-server/src/log/log.contorller.spec.ts
@@ -18,6 +18,7 @@ describe('LogController 테스트', () => {
         elapsedTime: jest.fn(),
         trafficRank: jest.fn(),
         getResponseSuccessRate: jest.fn(),
+        getResponseSuccessRateByProject: jest.fn(),
         getTrafficByGeneration: jest.fn(),
         getPathSpeedRankByProject: jest.fn(),
         getTrafficByProject: jest.fn(),
@@ -127,6 +128,53 @@ describe('LogController 테스트', () => {
             expect(result).toEqual({ success_rate: 98.5 });
             expect(service.getResponseSuccessRate).toHaveBeenCalledWith(mockSuccessRateDto);
             expect(service.getResponseSuccessRate).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('getResponseSuccessRateByProject()는 ', () => {
+        const mockRequestDto = { projectName: 'example-project' };
+        const mockServiceResponse = {
+            projectName: 'example-project',
+            success_rate: 95.5,
+        };
+
+        it('해당 프로젝트의 응답 성공률을 반환해야 한다', async () => {
+            mockLogService.getResponseSuccessRateByProject.mockResolvedValue(mockServiceResponse);
+
+            const result = await controller.getResponseSuccessRateByProject(mockRequestDto);
+
+            expect(result).toEqual(mockServiceResponse);
+            expect(result).toHaveProperty('projectName', 'example-project');
+            expect(result).toHaveProperty('success_rate', 95.5);
+            expect(service.getResponseSuccessRateByProject).toHaveBeenCalledWith(mockRequestDto);
+            expect(service.getResponseSuccessRateByProject).toHaveBeenCalledTimes(1);
+        });
+
+        it('서비스 호출 시, 에러가 발생하면 예외를 throw 해야 한다', async () => {
+            const error = new Error('Database error');
+            mockLogService.getResponseSuccessRateByProject.mockRejectedValue(error);
+
+            await expect(
+                controller.getResponseSuccessRateByProject(mockRequestDto),
+            ).rejects.toThrow(error);
+
+            expect(service.getResponseSuccessRateByProject).toHaveBeenCalledWith(mockRequestDto);
+            expect(service.getResponseSuccessRateByProject).toHaveBeenCalledTimes(1);
+        });
+
+        it('성공률이 100%인 경우에도 정상적으로 반환해야 한다', async () => {
+            const perfectRateResponse = {
+                projectName: 'example-project',
+                success_rate: 100,
+            };
+            mockLogService.getResponseSuccessRateByProject.mockResolvedValue(perfectRateResponse);
+
+            const result = await controller.getResponseSuccessRateByProject(mockRequestDto);
+
+            expect(result).toEqual(perfectRateResponse);
+            expect(result.success_rate).toBe(100);
+            expect(service.getResponseSuccessRateByProject).toHaveBeenCalledWith(mockRequestDto);
+            expect(service.getResponseSuccessRateByProject).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/backend/console-server/src/log/log.controller.ts
+++ b/backend/console-server/src/log/log.controller.ts
@@ -8,6 +8,7 @@ import { GetTrafficByProjectResponseDto } from './dto/get-traffic-by-project-res
 import { GetTrafficByProjectDto } from './dto/get-traffic-by-project.dto';
 import { GetSuccessRateResponseDto } from './dto/get-success-rate-response.dto';
 import { GetSuccessRateDto } from './dto/get-success-rate.dto';
+import { GetTrafficByGenerationDto } from './dto/get-traffic-by-generation.dto';
 
 @Controller('log')
 export class LogController {
@@ -83,15 +84,15 @@ export class LogController {
     @HttpCode(HttpStatus.OK)
     @ApiOperation({
         summary: '기수 내 총 트래픽',
-        description: '요청받은 기수의 기수 내 총 트래픽를 반환합니다.',
+        description: ' 요청받은 기수의 기수 내 총 트래픽를 반환합니다.',
     })
     @ApiResponse({
         status: 200,
         description: '기수 내 총 트래픽가 정상적으로 반환됨.',
-        type: ProjectResponseDto,
+        type: GetTrafficByProjectResponseDto,
     })
-    async trafficByGeneration() {
-        return await this.logService.trafficByGeneration();
+    async getTrafficByGeneration(@Query() getTrafficByGenerationDto: GetTrafficByGenerationDto) {
+        return await this.logService.getTrafficByGeneration(getTrafficByGenerationDto);
     }
 
     @Get('/elapsed-time/path-rank')

--- a/backend/console-server/src/log/log.controller.ts
+++ b/backend/console-server/src/log/log.controller.ts
@@ -50,7 +50,7 @@ export class LogController {
         return await this.logService.trafficRank();
     }
 
-    @Get('/response-rate')
+    @Get('/success-rate')
     @HttpCode(HttpStatus.OK)
     @ApiOperation({
         summary: '기수 내 응답 성공률',
@@ -63,6 +63,14 @@ export class LogController {
     })
     async getResponseSuccessRate(getSuccessRateDto: GetSuccessRateDto) {
         return await this.logService.getResponseSuccessRate(getSuccessRateDto);
+    }
+
+    @Get('/success-rate/project')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({})
+    @ApiResponse({})
+    async getResponseSuccessRateByProject(){
+        // return await this.logService.getResponseSuccessRate();
     }
 
     @Get('/traffic/project')

--- a/backend/console-server/src/log/log.controller.ts
+++ b/backend/console-server/src/log/log.controller.ts
@@ -6,6 +6,8 @@ import { GetPathSpeedRankDto } from './dto/get-path-speed-rank.dto';
 import { GetPathSpeedRankResponseDto } from './dto/get-path-speed-rank-response.dto';
 import { GetTrafficByProjectResponseDto } from './dto/get-traffic-by-project-response.dto';
 import { GetTrafficByProjectDto } from './dto/get-traffic-by-project.dto';
+import { GetSuccessRateResponseDto } from './dto/get-success-rate-response.dto';
+import { GetSuccessRateDto } from './dto/get-success-rate.dto';
 
 @Controller('log')
 export class LogController {
@@ -56,10 +58,10 @@ export class LogController {
     @ApiResponse({
         status: 200,
         description: '기수 내 응답 성공률이 성공적으로 반환됨.',
-        type: ProjectResponseDto,
+        type: GetSuccessRateResponseDto,
     })
-    async responseSuccessRate() {
-        return await this.logService.responseSuccessRate();
+    async getResponseSuccessRate(getSuccessRateDto: GetSuccessRateDto) {
+        return await this.logService.getResponseSuccessRate(getSuccessRateDto);
     }
 
     @Get('/traffic/project')

--- a/backend/console-server/src/log/log.controller.ts
+++ b/backend/console-server/src/log/log.controller.ts
@@ -9,6 +9,7 @@ import { GetTrafficByProjectDto } from './dto/get-traffic-by-project.dto';
 import { GetSuccessRateResponseDto } from './dto/get-success-rate-response.dto';
 import { GetSuccessRateDto } from './dto/get-success-rate.dto';
 import { GetTrafficByGenerationDto } from './dto/get-traffic-by-generation.dto';
+import { GetSuccessRateByProjectDto } from './dto/get-success-rate-by-project.dto';
 
 @Controller('log')
 export class LogController {
@@ -67,10 +68,19 @@ export class LogController {
 
     @Get('/success-rate/project')
     @HttpCode(HttpStatus.OK)
-    @ApiOperation({})
-    @ApiResponse({})
-    async getResponseSuccessRateByProject(){
-        // return await this.logService.getResponseSuccessRate();
+    @ApiOperation({
+        summary: '프로젝트 별 응답 성공률',
+        description: '요청받은 프로젝트의 응답 성공률을 성공적으로 반환합니다.',
+    })
+    @ApiResponse({
+        status: 200,
+        description: '프로젝트 별 응답 성공률이 성공적으로 반환됨.',
+        type: GetSuccessRateByProjectDto,
+    })
+    async getResponseSuccessRateByProject(
+        @Query() getSuccessRateByProjectDto: GetSuccessRateByProjectDto,
+    ) {
+        return await this.logService.getResponseSuccessRateByProject(getSuccessRateByProjectDto);
     }
 
     @Get('/traffic/project')

--- a/backend/console-server/src/log/log.repository.spec.ts
+++ b/backend/console-server/src/log/log.repository.spec.ts
@@ -126,6 +126,44 @@ describe('LogRepository 테스트', () => {
         });
     });
 
+    describe('findResponseSuccessRateByProject()는 ', () => {
+        const domain = 'example.com';
+
+        it('프로젝트별 성공률을 올바르게 계산할 수 있어야 한다', async () => {
+            const mockQueryResult = [{ is_error_rate: 1.5 }];
+            (clickhouse.query as jest.Mock).mockResolvedValue(mockQueryResult);
+
+            const result = await repository.findResponseSuccessRateByProject(domain);
+
+            const expectedQuery = `SELECT (sum(is_error) / count(*)) * 100 as is_error_rate
+    FROM (SELECT is_error, timestamp
+    FROM http_log WHERE host = {host:String} ORDER BY timestamp DESC LIMIT 1000) as subquery`;
+
+            expect(result).toEqual({ success_rate: 98.5 });
+            expect(clickhouse.query).toHaveBeenCalledWith(
+                expectedQuery,
+                expect.objectContaining({ host: domain }),
+            );
+        });
+
+        it('에러율이 0%일 때 성공률 100%를 반환해야 한다', async () => {
+            (clickhouse.query as jest.Mock).mockResolvedValue([{ is_error_rate: 0 }]);
+
+            const result = await repository.findResponseSuccessRateByProject(domain);
+
+            expect(result).toEqual({ success_rate: 100 });
+        });
+
+        it('쿼리 에러 발생시 예외를 throw 해야 한다', async () => {
+            const error = new Error('Clickhouse connection error');
+            (clickhouse.query as jest.Mock).mockRejectedValue(error);
+
+            await expect(repository.findResponseSuccessRateByProject(domain)).rejects.toThrow(
+                'Clickhouse connection error',
+            );
+        });
+    });
+
     describe('findTrafficByGeneration()는 ', () => {
         it('전체 트래픽 수를 반환해야 한다.', async () => {
             const mockResult = [{ count: 5000 }];

--- a/backend/console-server/src/log/log.repository.spec.ts
+++ b/backend/console-server/src/log/log.repository.spec.ts
@@ -107,14 +107,13 @@ describe('LogRepository 테스트', () => {
     describe('findResponseSuccessRate()는 ', () => {
         it('성공률을 올바르게 계산할 수 있어야 한다.', async () => {
             const mockQueryResult = [{ is_error_rate: 1.5 }];
-            mockClickhouse.query.mockResolvedValue(mockQueryResult);
+            (clickhouse.query as jest.Mock).mockResolvedValue(mockQueryResult);
 
             const result = await repository.findResponseSuccessRate();
 
             expect(result).toEqual({ success_rate: 98.5 });
             expect(clickhouse.query).toHaveBeenCalledWith(
-                expect.stringMatching(/SELECT.*sum\(is_error\).*count\(\*\).*as is_error_rate/s),
-                expect.any(Object),
+                "SELECT (sum(is_error) / count(*)) * 100 as is_error_rate\n    FROM http_log"
             );
         });
 

--- a/backend/console-server/src/log/log.repository.spec.ts
+++ b/backend/console-server/src/log/log.repository.spec.ts
@@ -113,7 +113,7 @@ describe('LogRepository 테스트', () => {
 
             expect(result).toEqual({ success_rate: 98.5 });
             expect(clickhouse.query).toHaveBeenCalledWith(
-                "SELECT (sum(is_error) / count(*)) * 100 as is_error_rate\n    FROM http_log"
+                'SELECT (sum(is_error) / count(*)) * 100 as is_error_rate\n    FROM http_log',
             );
         });
 
@@ -133,7 +133,7 @@ describe('LogRepository 테스트', () => {
 
             const result = await repository.findTrafficByGeneration();
 
-            expect(result).toEqual(mockResult[0]);
+            expect(result).toEqual(mockResult);
             expect(clickhouse.query).toHaveBeenCalledWith(
                 expect.stringMatching(/SELECT.*count\(\).*as count/s),
                 expect.any(Object),

--- a/backend/console-server/src/log/log.repository.ts
+++ b/backend/console-server/src/log/log.repository.ts
@@ -66,6 +66,25 @@ export class LogRepository {
         };
     }
 
+    async findResponseSuccessRateByProject(domain: string) {
+        const queryBuilder = new TimeSeriesQueryBuilder()
+            .metrics([
+                {
+                    name: 'is_error',
+                    aggregation: 'rate',
+                },
+            ])
+            .from('http_log')
+            .filter({ host: domain })
+            .build();
+
+        const result = await this.clickhouse.query(queryBuilder.query, queryBuilder.params);
+
+        return {
+            success_rate: 100 - (result as Array<{ is_error_rate: number }>)[0].is_error_rate,
+        };
+    }
+
     async findTrafficByGeneration() {
         const { query, params } = new TimeSeriesQueryBuilder()
             .metrics([

--- a/backend/console-server/src/log/log.repository.ts
+++ b/backend/console-server/src/log/log.repository.ts
@@ -78,7 +78,7 @@ export class LogRepository {
             .build();
 
         const result = await this.clickhouse.query(query, params);
-        return result[0];
+        return [{ count: ((result as unknown[])[0] as { count: number }).count }];
     }
 
     async getPathSpeedRankByProject(domain: string) {

--- a/backend/console-server/src/log/log.repository.ts
+++ b/backend/console-server/src/log/log.repository.ts
@@ -50,7 +50,7 @@ export class LogRepository {
     }
 
     async findResponseSuccessRate() {
-        const { query, params } = new TimeSeriesQueryBuilder()
+        const { query } = new TimeSeriesQueryBuilder()
             .metrics([
                 {
                     name: 'is_error',
@@ -60,7 +60,7 @@ export class LogRepository {
             .from('http_log')
             .build();
 
-        const result = await this.clickhouse.query(query, params);
+        const result = await this.clickhouse.query(query);
         return {
             success_rate: 100 - (result as Array<{ is_error_rate: number }>)[0].is_error_rate,
         };

--- a/backend/console-server/src/log/log.service.spec.ts
+++ b/backend/console-server/src/log/log.service.spec.ts
@@ -7,6 +7,7 @@ import { Project } from '../project/entities/project.entity';
 import { NotFoundException } from '@nestjs/common';
 import type { GetTrafficByGenerationResponseDto } from './dto/get-traffic-by-generation-response.dto';
 import { GetTrafficByGenerationDto } from './dto/get-traffic-by-generation.dto';
+import { GetSuccessRateByProjectResponseDTO } from './dto/get-success-rate-by-project-response.dto';
 
 describe('LogService 테스트', () => {
     let service: LogService;
@@ -163,6 +164,22 @@ describe('LogService 테스트', () => {
                     success_rate: mockSuccessRate.success_rate,
                 }),
             );
+        });
+
+        it('응답이 GetSuccessRateByProjectResponseDTO 형태로 변환되어야 한다', async () => {
+            const projectRepository = service['projectRepository'];
+            projectRepository.findOne = jest.fn().mockResolvedValue(mockProject);
+
+            mockLogRepository.findResponseSuccessRateByProject.mockResolvedValue(mockSuccessRate);
+
+            const result = await service.getResponseSuccessRateByProject(mockRequestDto);
+
+            expect(result).toBeInstanceOf(GetSuccessRateByProjectResponseDTO);
+            expect(Object.keys(result)).toContain('projectName');
+            expect(Object.keys(result)).toContain('success_rate');
+            expect(Object.keys(result).length).toBe(2);
+            expect(result.projectName).toBe(mockRequestDto.projectName);
+            expect(result.success_rate).toBe(mockSuccessRate.success_rate);
         });
 
         it('존재하지 않는 프로젝트명을 받은 경우, NotFoundException을 던져야 한다', async () => {

--- a/backend/console-server/src/log/log.service.spec.ts
+++ b/backend/console-server/src/log/log.service.spec.ts
@@ -118,12 +118,14 @@ describe('LogService 테스트', () => {
 
     describe('responseSuccessRate()는 ', () => {
         it('응답 성공률을 반환할 수 있어야 한다.', async () => {
-            const mockRate = { success_rate: 98.5 };
-            mockLogRepository.findResponseSuccessRate.mockResolvedValue(mockRate);
+            const mockSuccessRateDto = { generation: 5 };
+            const mockRepositoryResponse = { success_rate: 98.5 };
+            mockLogRepository.findResponseSuccessRate.mockResolvedValue(mockRepositoryResponse);
+            const expectedResult = { success_rate: 98.5 };
 
-            const result = await service.responseSuccessRate();
+            const result = await service.getResponseSuccessRate(mockSuccessRateDto);
 
-            expect(result).toEqual(mockRate);
+            expect(result).toEqual(expectedResult);
             expect(repository.findResponseSuccessRate).toHaveBeenCalled();
         });
     });

--- a/backend/console-server/src/log/log.service.spec.ts
+++ b/backend/console-server/src/log/log.service.spec.ts
@@ -5,6 +5,8 @@ import { LogRepository } from './log.repository';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Project } from '../project/entities/project.entity';
 import { NotFoundException } from '@nestjs/common';
+import type { GetTrafficByGenerationResponseDto } from './dto/get-traffic-by-generation-response.dto';
+import { GetTrafficByGenerationDto } from './dto/get-traffic-by-generation.dto';
 
 describe('LogService 테스트', () => {
     let service: LogService;
@@ -118,7 +120,7 @@ describe('LogService 테스트', () => {
 
     describe('responseSuccessRate()는 ', () => {
         it('응답 성공률을 반환할 수 있어야 한다.', async () => {
-            const mockSuccessRateDto = { generation: 5 };
+            const mockSuccessRateDto = { generation: 9 };
             const mockRepositoryResponse = { success_rate: 98.5 };
             mockLogRepository.findResponseSuccessRate.mockResolvedValue(mockRepositoryResponse);
             const expectedResult = { success_rate: 98.5 };
@@ -131,18 +133,27 @@ describe('LogService 테스트', () => {
     });
 
     describe('trafficByGeneration()는 ', () => {
-        it('기수별 트래픽을 올바르게 반환할 수 있어야 한다.', async () => {
+        it('기수별 트래픽의 총합을 올바르게 반환할 수 있어야 한다.', async () => {
             const mockStats = [
                 { generation: '10s', count: 500 },
                 { generation: '20s', count: 300 },
                 { generation: '30s', count: 200 },
             ];
-            mockLogRepository.findTrafficByGeneration.mockResolvedValue(mockStats);
+            const expectedTotalCount = mockStats.reduce((sum, stat) => sum + stat.count, 0);
+            const dto = new GetTrafficByGenerationDto();
+            dto.generation = 9;
 
-            const result = await service.trafficByGeneration();
+            const mockRepositoryResponse = [{ count: expectedTotalCount }];
+            const expectedResponse: GetTrafficByGenerationResponseDto = {
+                count: expectedTotalCount,
+            };
+            mockLogRepository.findTrafficByGeneration.mockResolvedValue(mockRepositoryResponse);
 
-            expect(result).toEqual(mockStats);
-            expect(repository.findTrafficByGeneration).toHaveBeenCalled();
+            const result = await service.getTrafficByGeneration(dto);
+
+            expect(result).toEqual(expectedResponse);
+            expect(mockLogRepository.findTrafficByGeneration).toHaveBeenCalledTimes(1);
+            expect(mockLogRepository.findTrafficByGeneration).toHaveBeenCalled();
         });
     });
 

--- a/backend/console-server/src/log/log.service.ts
+++ b/backend/console-server/src/log/log.service.ts
@@ -45,17 +45,13 @@ export class LogService {
     async getResponseSuccessRate(_getSuccessRateDto: GetSuccessRateDto) {
         const result = await this.logRepository.findResponseSuccessRate();
 
-        return plainToInstance(GetSuccessRateResponseDto, {
-            success_rate: result.success_rate,
-        });
+        return plainToInstance(GetSuccessRateResponseDto, result);
     }
 
     async getTrafficByGeneration(_getTrafficByGenerationDto: GetTrafficByGenerationDto) {
         const result = await this.logRepository.findTrafficByGeneration();
 
-        return plainToInstance(GetTrafficByGenerationDto, {
-            count: result[0].count,
-        });
+        return plainToInstance(GetTrafficByGenerationDto, result[0]);
     }
 
     async getPathSpeedRankByProject(getPathSpeedRankDto: GetPathSpeedRankDto) {

--- a/backend/console-server/src/log/log.service.ts
+++ b/backend/console-server/src/log/log.service.ts
@@ -11,6 +11,8 @@ import { GetTrafficByProjectResponseDto } from './dto/get-traffic-by-project-res
 import { GetSuccessRateResponseDto } from './dto/get-success-rate-response.dto';
 import { GetSuccessRateDto } from './dto/get-success-rate.dto';
 import { GetTrafficByGenerationDto } from './dto/get-traffic-by-generation.dto';
+import { GetSuccessRateByProjectResponseDTO } from './dto/get-success-rate-by-project-response.dto';
+import { GetSuccessRateByProjectDto } from './dto/get-success-rate-by-project.dto';
 
 @Injectable()
 export class LogService {
@@ -46,6 +48,21 @@ export class LogService {
         const result = await this.logRepository.findResponseSuccessRate();
 
         return plainToInstance(GetSuccessRateResponseDto, result);
+    }
+
+    async getResponseSuccessRateByProject(getSuccessRateByProjectDto: GetSuccessRateByProjectDto) {
+        const { projectName } = getSuccessRateByProjectDto;
+
+        const project = await this.projectRepository.findOne({
+            where: { name: projectName },
+            select: ['domain'],
+        });
+
+        if (!project) throw new NotFoundException(`Project with name ${projectName} not found`);
+
+        const result = await this.logRepository.findResponseSuccessRateByProject(project.domain);
+
+        return plainToInstance(GetSuccessRateByProjectResponseDTO, result);
     }
 
     async getTrafficByGeneration(_getTrafficByGenerationDto: GetTrafficByGenerationDto) {

--- a/backend/console-server/src/log/log.service.ts
+++ b/backend/console-server/src/log/log.service.ts
@@ -8,6 +8,8 @@ import { GetPathSpeedRankDto } from './dto/get-path-speed-rank.dto';
 import { GetPathSpeedRankResponseDto } from './dto/get-path-speed-rank-response.dto';
 import { GetTrafficByProjectDto } from './dto/get-traffic-by-project.dto';
 import { GetTrafficByProjectResponseDto } from './dto/get-traffic-by-project-response.dto';
+import { GetSuccessRateResponseDto } from './dto/get-success-rate-response.dto';
+import { GetSuccessRateDto } from './dto/get-success-rate.dto';
 
 @Injectable()
 export class LogService {
@@ -39,10 +41,12 @@ export class LogService {
         return result.slice(0, 5);
     }
 
-    async responseSuccessRate() {
+    async getResponseSuccessRate(_getSuccessRateDto: GetSuccessRateDto) {
         const result = await this.logRepository.findResponseSuccessRate();
 
-        return result;
+        return plainToInstance(GetSuccessRateResponseDto, {
+            success_rate: result.success_rate,
+        });
     }
 
     async trafficByGeneration() {

--- a/backend/console-server/src/log/log.service.ts
+++ b/backend/console-server/src/log/log.service.ts
@@ -10,6 +10,7 @@ import { GetTrafficByProjectDto } from './dto/get-traffic-by-project.dto';
 import { GetTrafficByProjectResponseDto } from './dto/get-traffic-by-project-response.dto';
 import { GetSuccessRateResponseDto } from './dto/get-success-rate-response.dto';
 import { GetSuccessRateDto } from './dto/get-success-rate.dto';
+import { GetTrafficByGenerationDto } from './dto/get-traffic-by-generation.dto';
 
 @Injectable()
 export class LogService {
@@ -49,10 +50,12 @@ export class LogService {
         });
     }
 
-    async trafficByGeneration() {
+    async getTrafficByGeneration(_getTrafficByGenerationDto: GetTrafficByGenerationDto) {
         const result = await this.logRepository.findTrafficByGeneration();
 
-        return result;
+        return plainToInstance(GetTrafficByGenerationDto, {
+            count: result[0].count,
+        });
     }
 
     async getPathSpeedRankByProject(getPathSpeedRankDto: GetPathSpeedRankDto) {

--- a/backend/console-server/src/log/log.service.ts
+++ b/backend/console-server/src/log/log.service.ts
@@ -62,7 +62,10 @@ export class LogService {
 
         const result = await this.logRepository.findResponseSuccessRateByProject(project.domain);
 
-        return plainToInstance(GetSuccessRateByProjectResponseDTO, result);
+        return plainToInstance(GetSuccessRateByProjectResponseDTO, {
+            projectName,
+            ...result,
+        });
     }
 
     async getTrafficByGeneration(_getTrafficByGenerationDto: GetTrafficByGenerationDto) {

--- a/backend/proxy-server/package-lock.json
+++ b/backend/proxy-server/package-lock.json
@@ -108,16 +108,6 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/generator": {
       "version": "7.26.2",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.2.tgz",
@@ -179,16 +169,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.9.tgz",
@@ -211,16 +191,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.25.9.tgz",
@@ -239,20 +209,10 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.2.tgz",
-      "integrity": "sha512-LV76g+C502biUK6AyZ3LK10vDpDyCzZnhZFXkH1L75zHPj68+qc8Zfpx2th+gzwA2MzyK+1g/3EPl62yFnVttQ==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.3.tgz",
+      "integrity": "sha512-HK7Bi+Hj6H+VTHA3ZvBis7V/6hu9QuTrnMXNybfUf2iiuU/N97I8VjB+KbhFF8Rld/Lx5MzoCwPCpPjfK+n8Cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1786,16 +1746,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/preset-env/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/preset-modules": {
       "version": "0.1.6-no-external-plugins",
       "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
@@ -1900,21 +1850,21 @@
       "license": "MIT"
     },
     "node_modules/@clickhouse/client": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@clickhouse/client/-/client-1.8.0.tgz",
-      "integrity": "sha512-IJ+/r3Wbg2t67sEtTA9dUgP2HjyGuze7ksNqeDfb7Ahnws1dzSVP2kg1Y9xOrb2e37K29JWWr26cX+rOiESm1A==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@clickhouse/client/-/client-1.8.1.tgz",
+      "integrity": "sha512-Ec0pCdwftIPD7hCxhOukHS0Zxr2tDc5mNAHBqkT3c0c6GO2WQdZkME9+EcfGcoF7+foUp82F5a0bPfSDDjfWmg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@clickhouse/client-common": "1.8.0"
+        "@clickhouse/client-common": "1.8.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@clickhouse/client-common": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@clickhouse/client-common/-/client-common-1.8.0.tgz",
-      "integrity": "sha512-aQgH0UODGuFHfL8rgeLSrGCoh3NCoNUs0tFGl0o79iyfASfvWtT/K/X3RM0QJpXXOgXpB//T2nD5XvCFtdk32w==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@clickhouse/client-common/-/client-common-1.8.1.tgz",
+      "integrity": "sha512-Z0R5zKaS3N35Op338WVRHIfoqDh9gotXZwekm0lbHQmwNaj3nY2iJ113dFYKjb1V+ESu+PvLEA//LJUGZyPQOg==",
       "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2355,9 +2305,9 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.18.0.tgz",
-      "integrity": "sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.0.tgz",
+      "integrity": "sha512-zdHg2FPIFNKPdcHWtiNT+jEFCHYVplAXRDlQDyqy0zGx/q2parwh7brGJSiTxRk/TSMkbM//zt/f5CHgyTyaSQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2370,9 +2320,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.7.0.tgz",
-      "integrity": "sha512-xp5Jirz5DyPYlPiKat8jaq0EmYvDXKKpzTbxXMpT9eqlRJkRKIz9AGMdlvYjih+im+QlhWrpvVjl8IPC/lHlUw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.0.tgz",
+      "integrity": "sha512-7ATR9F0e4W85D/0w7cU0SNj7qkAexMG+bAHEZOjo9akvGuhHE2m7umzWzfnpa0XAg5Kxc1BWmtPMV67jJ+9VUg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2380,9 +2330,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
-      "integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
+      "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2403,23 +2353,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -2433,17 +2366,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@eslint/js": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.14.0.tgz",
-      "integrity": "sha512-pFoEtFWCPyDOl+C6Ift+wC7Ro89otjigCf5vcuWqWgqNSQbRrpjSvdeE6ofLz4dHmyxD5f7gIdGT4+p36L6Twg==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.15.0.tgz",
+      "integrity": "sha512-tMTqrY+EzbXmKJR5ToI8lxu7jaN5EdmrBFJpQk5JmSlyLsx6o4t27r883K5xsLuCYCpfKBCGswMSWXsM+jB7lg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2461,9 +2387,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.2.tgz",
-      "integrity": "sha512-CXtq5nR4Su+2I47WPOlWud98Y5Lv8Kyxp2ukhgFx/eW6Blm18VXJO5WuQylPugRo8nbluoi6GvvxBLqHcvqUUw==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
+      "integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2483,6 +2409,28 @@
         "ajv-formats": "^3.0.1",
         "fast-uri": "^3.0.0"
       }
+    },
+    "node_modules/@fastify/ajv-compiler/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@fastify/error": {
       "version": "4.0.0",
@@ -2509,16 +2457,16 @@
       }
     },
     "node_modules/@fastify/reply-from": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@fastify/reply-from/-/reply-from-11.0.1.tgz",
-      "integrity": "sha512-F2Qk88gcqIIiug9V+4I6WeeV1faj1Wu798JyOnwbJcjQhm4LYrHdkpFSVwJE0g1cVjYCFFmH3OVh1HHaninttQ==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@fastify/reply-from/-/reply-from-11.0.2.tgz",
+      "integrity": "sha512-VcHhe01PsHuVX2eVrkoskCs+pwNPgVfOOpwQJnSo3AwIKtISm0VCFB7bycQjHfxAuPYgkrI6ZvYoovdHx4sVMA==",
       "license": "MIT",
       "dependencies": {
         "@fastify/error": "^4.0.0",
         "end-of-stream": "^1.4.4",
         "fast-content-type-parse": "^2.0.0",
         "fast-querystring": "^1.1.2",
-        "fastify-plugin": "^4.5.1",
+        "fastify-plugin": "^5.0.1",
         "toad-cache": "^3.7.0",
         "undici": "^6.11.1"
       }
@@ -2839,6 +2787,19 @@
         "@istanbuljs/schema": "^0.1.3",
         "istanbul-lib-coverage": "^3.2.0",
         "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
@@ -3231,21 +3192,6 @@
         "form-data": "^4.0.0"
       }
     },
-    "node_modules/@types/superagent/node_modules/form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@types/supertest": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.2.tgz",
@@ -3275,17 +3221,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.13.0.tgz",
-      "integrity": "sha512-nQtBLiZYMUPkclSeC3id+x4uVd1SGtHuElTxL++SfP47jR0zfkZBJHc+gL4qPsgTuypz0k8Y2GheaDYn6Gy3rg==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.15.0.tgz",
+      "integrity": "sha512-+zkm9AR1Ds9uLWN3fkoeXgFppaQ+uEVtfOV62dDmsy9QCNqlRHWNEck4yarvRNrvRcHQLGfqBNui3cimoz8XAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.13.0",
-        "@typescript-eslint/type-utils": "8.13.0",
-        "@typescript-eslint/utils": "8.13.0",
-        "@typescript-eslint/visitor-keys": "8.13.0",
+        "@typescript-eslint/scope-manager": "8.15.0",
+        "@typescript-eslint/type-utils": "8.15.0",
+        "@typescript-eslint/utils": "8.15.0",
+        "@typescript-eslint/visitor-keys": "8.15.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -3309,16 +3255,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.13.0.tgz",
-      "integrity": "sha512-w0xp+xGg8u/nONcGw1UXAr6cjCPU1w0XVyBs6Zqaj5eLmxkKQAByTdV/uGgNN5tVvN/kKpoQlP2cL7R+ajZZIQ==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.15.0.tgz",
+      "integrity": "sha512-7n59qFpghG4uazrF9qtGKBZXn7Oz4sOMm8dwNWDQY96Xlm2oX67eipqcblDj+oY1lLCbf1oltMZFpUso66Kl1A==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.13.0",
-        "@typescript-eslint/types": "8.13.0",
-        "@typescript-eslint/typescript-estree": "8.13.0",
-        "@typescript-eslint/visitor-keys": "8.13.0",
+        "@typescript-eslint/scope-manager": "8.15.0",
+        "@typescript-eslint/types": "8.15.0",
+        "@typescript-eslint/typescript-estree": "8.15.0",
+        "@typescript-eslint/visitor-keys": "8.15.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -3338,14 +3284,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.13.0.tgz",
-      "integrity": "sha512-XsGWww0odcUT0gJoBZ1DeulY1+jkaHUciUq4jKNv4cpInbvvrtDoyBH9rE/n2V29wQJPk8iCH1wipra9BhmiMA==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.15.0.tgz",
+      "integrity": "sha512-QRGy8ADi4J7ii95xz4UoiymmmMd/zuy9azCaamnZ3FM8T5fZcex8UfJcjkiEZjJSztKfEBe3dZ5T/5RHAmw2mA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.13.0",
-        "@typescript-eslint/visitor-keys": "8.13.0"
+        "@typescript-eslint/types": "8.15.0",
+        "@typescript-eslint/visitor-keys": "8.15.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3356,14 +3302,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.13.0.tgz",
-      "integrity": "sha512-Rqnn6xXTR316fP4D2pohZenJnp+NwQ1mo7/JM+J1LWZENSLkJI8ID8QNtlvFeb0HnFSK94D6q0cnMX6SbE5/vA==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.15.0.tgz",
+      "integrity": "sha512-UU6uwXDoI3JGSXmcdnP5d8Fffa2KayOhUUqr/AiBnG1Gl7+7ut/oyagVeSkh7bxQ0zSXV9ptRh/4N15nkCqnpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.13.0",
-        "@typescript-eslint/utils": "8.13.0",
+        "@typescript-eslint/typescript-estree": "8.15.0",
+        "@typescript-eslint/utils": "8.15.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -3374,6 +3320,9 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
@@ -3381,9 +3330,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.13.0.tgz",
-      "integrity": "sha512-4cyFErJetFLckcThRUFdReWJjVsPCqyBlJTi6IDEpc1GWCIIZRFxVppjWLIMcQhNGhdWJJRYFHpHoDWvMlDzng==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.15.0.tgz",
+      "integrity": "sha512-n3Gt8Y/KyJNe0S3yDCD2RVKrHBC4gTUcLTebVBXacPy091E6tNspFLKRXlk3hwT4G55nfr1n2AdFqi/XMxzmPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3395,14 +3344,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.13.0.tgz",
-      "integrity": "sha512-v7SCIGmVsRK2Cy/LTLGN22uea6SaUIlpBcO/gnMGT/7zPtxp90bphcGf4fyrCQl3ZtiBKqVTG32hb668oIYy1g==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.15.0.tgz",
+      "integrity": "sha512-1eMp2JgNec/niZsR7ioFBlsh/Fk0oJbhaqO0jRyQBMgkz7RrFfkqF9lYYmBoGBaSiLnu8TAPQTwoTUiSTUW9dg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "8.13.0",
-        "@typescript-eslint/visitor-keys": "8.13.0",
+        "@typescript-eslint/types": "8.15.0",
+        "@typescript-eslint/visitor-keys": "8.15.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -3449,17 +3398,30 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.13.0.tgz",
-      "integrity": "sha512-A1EeYOND6Uv250nybnLZapeXpYMl8tkzYUxqmoKAWnI4sei3ihf2XdZVd+vVOmHGcp3t+P7yRrNsyyiXTvShFQ==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.15.0.tgz",
+      "integrity": "sha512-k82RI9yGhr0QM3Dnq+egEpz9qB6Un+WLYhmoNcvl8ltMEededhh7otBVVIDDsEEttauwdY/hQoSsOv13lxrFzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.13.0",
-        "@typescript-eslint/types": "8.13.0",
-        "@typescript-eslint/typescript-estree": "8.13.0"
+        "@typescript-eslint/scope-manager": "8.15.0",
+        "@typescript-eslint/types": "8.15.0",
+        "@typescript-eslint/typescript-estree": "8.15.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3470,17 +3432,22 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.13.0.tgz",
-      "integrity": "sha512-7N/+lztJqH4Mrf0lb10R/CbI1EaAMMGyF5y0oJvFoAhafwgiRA7TXyd8TFn8FC8k5y2dTsYogg238qavRGNnlw==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.15.0.tgz",
+      "integrity": "sha512-h8vYOulWec9LhpwfAdZf2bjr8xIp0KNKnpgqSz0qqYYKAW/QZKw3ktRndbiAtUz4acH4QLQavwZBYCc0wulA/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.13.0",
-        "eslint-visitor-keys": "^3.4.3"
+        "@typescript-eslint/types": "8.15.0",
+        "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3488,6 +3455,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/abstract-logging": {
@@ -3520,15 +3500,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       },
       "funding": {
         "type": "github",
@@ -3551,6 +3531,28 @@
           "optional": true
         }
       }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -3624,6 +3626,7 @@
       "engines": {
         "node": ">=8"
       }
+    },
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -3760,28 +3763,18 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.11.tgz",
-      "integrity": "sha512-sMEJ27L0gRHShOh5G54uAAPaiCOygY/5ratXuiyb2G46FmlSpc9eFCzYVyDiPxfNbwzA7mYahmjQc5q+CZQ09Q==",
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.12.tgz",
+      "integrity": "sha512-CPWT6BwvhrTO2d8QVorhTCQw9Y43zOu7G9HigcfxvepOU6b8o3tcWad6oVgZIsZCTt42FFv97aA7ZJsbM4+8og==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.22.6",
-        "@babel/helper-define-polyfill-provider": "^0.6.2",
+        "@babel/helper-define-polyfill-provider": "^0.6.3",
         "semver": "^6.3.1"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-      }
-    },
-    "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
@@ -3799,13 +3792,13 @@
       }
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.2.tgz",
-      "integrity": "sha512-2R25rQZWP63nGwaAswvDazbPXfrM3HwVoBXK6HcqeKrSrL/JqcC/rDcf95l4r7LXLyxDXc8uQDa064GubtCABg==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.3.tgz",
+      "integrity": "sha512-LiWSbl4CRSIa5x/JAU6jZiG9eit9w6mz+yVMFwDE83LAWvt0AfGBoZ7HS/mkhrKuh2ZlzfVZYKoLjXdqw6Yt7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.2"
+        "@babel/helper-define-polyfill-provider": "^0.6.3"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -4011,9 +4004,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001678",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001678.tgz",
-      "integrity": "sha512-RR+4U/05gNtps58PEBDZcPWTgEO2MBeoPZ96aQcjmfkBWRIDfN451fW2qyDA9/+HohLLIL5GqiMwA+IB1pWarw==",
+      "version": "1.0.30001680",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001680.tgz",
+      "integrity": "sha512-rPQy70G6AGUMnbwS1z6Xg+RkHYPAi18ihs47GH0jcxIG7wArmPgY3XbS2sRdBbxJljp3thdT8BIqv9ccCypiPA==",
       "dev": true,
       "funding": [
         {
@@ -4214,6 +4207,8 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || >=14"
+      }
+    },
     "node_modules/component-emitter": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
@@ -4295,9 +4290,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4487,9 +4482,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.52",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.52.tgz",
-      "integrity": "sha512-xtoijJTZ+qeucLBDNztDOuQBE1ksqjvNjvqFoST3nGC7fSpqJ+X6BdTBaY5BHG+IhWWmpc6b/KfpeuEDupEPOQ==",
+      "version": "1.5.63",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.63.tgz",
+      "integrity": "sha512-ddeXKuY9BHo/mw145axlyWjlJ1UBt4WK3AlvkT7W2AbqfRQoacVoRUCF6wL3uIx/8wT9oLKXzI+rFqHHscByaA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4617,27 +4612,27 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.14.0.tgz",
-      "integrity": "sha512-c2FHsVBr87lnUtjP4Yhvk4yEhKrQavGafRA/Se1ouse8PfbfC/Qh9Mxa00yWsZRlqeUB9raXip0aiiUZkgnr9g==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.15.0.tgz",
+      "integrity": "sha512-7CrWySmIibCgT1Os28lUU6upBshZ+GxybLOrmRzi08kS8MBuO8QA7pXEgYgY5W8vK3e74xv0lpjo9DbaGU9Rkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.18.0",
-        "@eslint/core": "^0.7.0",
-        "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "9.14.0",
-        "@eslint/plugin-kit": "^0.2.0",
+        "@eslint/config-array": "^0.19.0",
+        "@eslint/core": "^0.9.0",
+        "@eslint/eslintrc": "^3.2.0",
+        "@eslint/js": "9.15.0",
+        "@eslint/plugin-kit": "^0.2.3",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.0",
+        "@humanwhocodes/retry": "^0.4.1",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
+        "cross-spawn": "^7.0.5",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^8.2.0",
@@ -4656,8 +4651,7 @@
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
-        "text-table": "^0.2.0"
+        "optionator": "^0.9.3"
       },
       "bin": {
         "eslint": "bin/eslint.js"
@@ -4751,23 +4745,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
@@ -4797,13 +4774,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/eslint/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/eslint/node_modules/locate-path": {
       "version": "6.0.0",
@@ -5069,10 +5039,38 @@
         "rfdc": "^1.2.0"
       }
     },
+    "node_modules/fast-json-stringify/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/ajv/node_modules/fast-uri": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
+      "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fast-json-stringify/node_modules/fast-uri": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-2.4.0.tgz",
       "integrity": "sha512-ypuAmmMKInk5q7XcepxlnUWDLWv4GFtaJqAzWKqn62IpQ3pejtr5dTVbt3vwqVaMKmkNR55sTT+CqUKIaT21BA==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stringify/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -5146,10 +5144,22 @@
       }
     },
     "node_modules/fastify-plugin": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-4.5.1.tgz",
-      "integrity": "sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.0.1.tgz",
+      "integrity": "sha512-HCxs+YnRaWzCl+cWRYFnHmeRFyR5GVnJTAaCJQiYzQSDwK9MgJdyAsuL3nh0EWRCYMgQ5MeziymvmAhUHYHDUQ==",
       "license": "MIT"
+    },
+    "node_modules/fastify/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -5272,9 +5282,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
+      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5288,17 +5298,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
+        "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       },
       "engines": {
-        "node": ">= 0.12"
+        "node": ">= 6"
       }
     },
     "node_modules/formidable": {
@@ -5512,6 +5522,8 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -5560,28 +5572,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/har-validator/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/har-validator/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "license": "MIT"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -5941,16 +5931,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/istanbul-lib-report": {
@@ -6498,6 +6478,19 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jest-util": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
@@ -6668,9 +6661,9 @@
       }
     },
     "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -6886,6 +6879,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/make-error": {
@@ -7521,7 +7527,7 @@
         "punycode": "^2.3.1"
       }
     },
-    "node_modules/punycode": {
+    "node_modules/psl/node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
@@ -7529,6 +7535,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "license": "MIT"
     },
     "node_modules/pure-rand": {
       "version": "6.1.0",
@@ -7738,6 +7750,20 @@
         "node": ">= 4"
       }
     },
+    "node_modules/request/node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -7918,15 +7944,13 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/seq-queue": {
@@ -8226,24 +8250,10 @@
         "node": ">=14.18.0"
       }
     },
-    "node_modules/superagent/node_modules/form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/superagent/node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.1.tgz",
+      "integrity": "sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.0.6"
@@ -8326,13 +8336,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/thread-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
@@ -8389,12 +8392,6 @@
       "engines": {
         "node": ">=0.8"
       }
-    },
-    "node_modules/tough-cookie/node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "1.4.0",
@@ -8456,6 +8453,19 @@
         "esbuild": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/tsc-alias": {
@@ -8578,9 +8588,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.20.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.20.1.tgz",
-      "integrity": "sha512-AjQF1QsmqfJys+LXfGTNum+qw4S88CojRInG/6t31W/1fk6G59s92bnAvGz5Cmur+kQv2SURXEvvudLmbrE8QA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.0.tgz",
+      "integrity": "sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -8675,6 +8685,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uri-js/node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/uuid": {


### PR DESCRIPTION
### 👀 관련 이슈
#105 

### ✨ 작업한 내용
 - [x] 프로젝트 별 평균 응답 성공률 api 구현 
    - [x] get-success-rate-by-project.dto 생성
    - [x] get-success-rate-by-project-response 생성
    - [x] param으로 projectName 받아서 유효성 검증
- [x] 컨트롤러 계층 테스트 케이스 작성
- getResponseSuccessRateByProject()는
   ✓ 해당 프로젝트의 응답 성공률을 반환해야 한다 (1 ms)
   ✓ 서비스 호출 시, 에러가 발생하면 예외를 throw 해야 한다 (1 ms)
   ✓ 성공률이 100%인 경우에도 정상적으로 반환해야 한다 (1 ms)
- [x] 서비스 계층 테스트 케이스 작성
- getResponseSuccessRateByProject()는
   ✓ projectName을 이용해 도메인을 조회한 후 응답 성공률을 반환해야 한다 (2 ms)
   ✓ 존재하지 않는 프로젝트명을 받은 경우, NotFoundException을 던져야 한다 (1 ms)
   ✓ 레포지토리 호출 시, 에러가 발생하면, 예외를 throw 해야 한다 (1 ms)
- [x] 레포지토리 계층 테스트 케이스 작성
- findResponseSuccessRateByProject()는
   ✓ 프로젝트별 성공률을 올바르게 계산할 수 있어야 한다 (2 ms)
   ✓ 에러율이 0%일 때 성공률 100%를 반환해야 한다 (2 ms)
   ✓ 쿼리 에러 발생시 예외를 throw 해야 한다 (2 ms)


### 🍰 참고사항
테스트 커버리지입니다.
```
  get-success-rate-by-project-response.dto.ts |     100 |      100 |     100 |     100 |                   
  get-success-rate-by-project.dto.ts          |     100 |      100 |     100 |     100 |   
  log.controller.ts                           |     100 |      100 |     100 |     100 |             
  log.repository.ts                           |     100 |      100 |     100 |     100 |                   
  log.service.ts                              |     100 |      100 |     100 |     100 |  
```


### 📷 스크린샷 또는 GIF
![image](https://github.com/user-attachments/assets/eb8ac485-87c5-47bb-8f8d-bbed3d8f602e)
