### PR TITLE
[BE] DAU 테이블 생성 및 NameServer에서 값 갱신

### DIFF
--- a/backend/console-server/src/clickhouse/clickhouse.ts
+++ b/backend/console-server/src/clickhouse/clickhouse.ts
@@ -87,7 +87,7 @@ export class Clickhouse implements OnModuleInit, OnModuleDestroy {
         return new Promise((resolve) => setTimeout(resolve, ms));
     }
 
-    async query<T>(query: string, params?: Record<string, any>): Promise<T[]> {
+    async query<T>(query: string, params?: Record<string, unknown>): Promise<T[]> {
         try {
             const resultSet = await this.client.query({
                 query,

--- a/backend/name-server/package-lock.json
+++ b/backend/name-server/package-lock.json
@@ -8,6 +8,7 @@
       "name": "name-server",
       "version": "1.0.0",
       "dependencies": {
+        "@clickhouse/client": "^1.8.1",
         "@types/better-sqlite3": "^7.6.11",
         "@types/dns-packet": "^5.6.5",
         "better-sqlite3": "^11.5.0",
@@ -1922,6 +1923,24 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@clickhouse/client": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@clickhouse/client/-/client-1.8.1.tgz",
+      "integrity": "sha512-Ec0pCdwftIPD7hCxhOukHS0Zxr2tDc5mNAHBqkT3c0c6GO2WQdZkME9+EcfGcoF7+foUp82F5a0bPfSDDjfWmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@clickhouse/client-common": "1.8.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@clickhouse/client-common": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@clickhouse/client-common/-/client-common-1.8.1.tgz",
+      "integrity": "sha512-Z0R5zKaS3N35Op338WVRHIfoqDh9gotXZwekm0lbHQmwNaj3nY2iJ113dFYKjb1V+ESu+PvLEA//LJUGZyPQOg==",
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.23.1",

--- a/backend/name-server/package.json
+++ b/backend/name-server/package.json
@@ -43,6 +43,7 @@
     "typescript": "^5.6.3"
   },
   "dependencies": {
+    "@clickhouse/client": "^1.8.1",
     "@types/better-sqlite3": "^7.6.11",
     "@types/dns-packet": "^5.6.5",
     "better-sqlite3": "^11.5.0",

--- a/backend/name-server/src/app.ts
+++ b/backend/name-server/src/app.ts
@@ -5,6 +5,7 @@ import { Server } from './server/server';
 import { db } from './database/mysql/mysql-database';
 import { logger } from './common/utils/logger/console.logger';
 import { ProjectQuery } from './database/query/project.query';
+import { DAURecorder } from 'database/query/dau-recorder';
 
 config();
 
@@ -15,9 +16,10 @@ export class Application {
         await this.initializeDatabase();
 
         const config = await this.initializeConfig();
+        const dauRecorder = new DAURecorder();
         const projectQuery = new ProjectQuery();
 
-        return new Server(config, projectQuery);
+        return new Server(config, dauRecorder, projectQuery);
     }
 
     public async cleanup(): Promise<void> {
@@ -36,6 +38,6 @@ export class Application {
 
     private async initializeDatabase(): Promise<void> {
         await db.connect();
-        logger.info('Database connection established');
+        logger.info('MySql Database connection established');
     }
 }

--- a/backend/name-server/src/database/clickhouse/clickhouse-database.ts
+++ b/backend/name-server/src/database/clickhouse/clickhouse-database.ts
@@ -1,0 +1,14 @@
+import { createClient } from '@clickhouse/client';
+import type { ClickHouseClient } from '@clickhouse/client';
+import { clickhouseConfig } from './config/clickhouse.config';
+
+export class ClickhouseDatabase {
+    private static instance: ClickHouseClient;
+
+    public static getInstance(): ClickHouseClient {
+        if (!ClickhouseDatabase.instance) {
+            ClickhouseDatabase.instance = createClient(clickhouseConfig);
+        }
+        return ClickhouseDatabase.instance;
+    }
+}

--- a/backend/name-server/src/database/clickhouse/config/clickhouse.config.ts
+++ b/backend/name-server/src/database/clickhouse/config/clickhouse.config.ts
@@ -1,0 +1,8 @@
+import { ClickHouseClientConfigOptions } from '@clickhouse/client';
+
+export const clickhouseConfig: ClickHouseClientConfigOptions = {
+    url: process.env.CLICKHOUSE_URL || 'http://localhost:8123',
+    username: process.env.CLICKHOUSE_USERNAME || 'default',
+    password: process.env.CLICKHOUSE_PASSWORD || '',
+    database: process.env.CLICKHOUSE_DATABASE,
+};

--- a/backend/name-server/src/database/query/dau-recorder.ts
+++ b/backend/name-server/src/database/query/dau-recorder.ts
@@ -1,0 +1,22 @@
+import { ClickhouseDatabase } from '../clickhouse/clickhouse-database';
+
+export interface DAURecorderInterface {
+    recordAccess(domain: string): Promise<void>;
+}
+
+export class DAURecorder implements DAURecorderInterface {
+    private clickhouseClient = ClickhouseDatabase.getInstance();
+    public async recordAccess(domain: string): Promise<void> {
+        const date = new Date().toISOString().slice(0, 10);
+        const values = [{ domain, date, access: 1 }];
+        try {
+            await this.clickhouseClient.insert({
+                table: 'dau',
+                values,
+                format: 'JSONEachRow',
+            });
+        } catch (error) {
+            console.error('ClickHouse Error:', error);
+        }
+    }
+}

--- a/backend/name-server/src/database/query/project.query.ts
+++ b/backend/name-server/src/database/query/project.query.ts
@@ -1,6 +1,6 @@
 import { db } from '../mysql/mysql-database';
 import type { RowDataPacket } from 'mysql2/promise';
-import { ProjectQueryInterface } from './project.query.interface';
+import type { ProjectQueryInterface } from './project.query.interface';
 
 interface ProjectExists extends RowDataPacket {
     exists_flag: number;

--- a/backend/name-server/src/server/utils/dns-response-builder.ts
+++ b/backend/name-server/src/server/utils/dns-response-builder.ts
@@ -52,7 +52,7 @@ export class DNSResponseBuilder {
                     name: question.name,
                     type: 'A',
                     class: 'IN',
-                    ttl: 10,
+                    ttl: 86400,
                     data: this.config.proxyServerIp,
                 },
             ];


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
- #16 
- #111 

### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
- [x] TTL 변경: DNS 응답의 TTL(Time To Live)을 86400초(1일)로 설정하여 클라이언트 측에서 하루 동안 캐싱되도록 변경하였습니다. 이를 통해 도메인별 DAU(Daily Active Users)의 근사치를 계산할 수 있습니다.
- [x] clickhouse.ts 구현: 프록시서버에 있는 코드를 사용하고, 네임서버에서 mysql을 사용하는 방식과 유사하게 구현하였습니다.
- [x] DAURecorder 클래스 구현: ClickHouse 데이터베이스의 dau 테이블에 DAU 데이터를 저장하는 로직을 구현하였습니다. 각 도메인에 대한 액세스가 발생할 때마다 dau = 1인 레코드를 삽입하고, SummingMergeTree 엔진을 사용하여 데이터를 집계합니다.
- [x] 서버 로직 수정: Server 클래스에서 DNS 쿼리를 처리할 때(handleMessage에서), 도메인이 유효한 경우 DAURecorder를 사용하여 DAU 데이터를 기록하도록 수정하였습니다.

### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->


### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->
- ClickHouse의 효율적인 UPDATE 방식: ClickHouse는 UPDATE 문이 얼마전까지 지원되지 않았으며, 이처럼 갱신이 잦은 상황에서 적절하지 않습니다. 데이터의 불변성을 유지하면서 효율적으로 집계할 수 있도록 SummingMergeTree 엔진을 사용하였습니다. 실제로 데이터 특성상 갱신되거나 삭제될 일이 없으니 적절한 접근이라 생각하였습니다.
   <details>
  <summary>DDL 보기</summary>
  
  ```sql
  create table default.dau
  (
      domain String,
      date   Date,
      access UInt64
  )
      engine = SummingMergeTree PARTITION BY toYYYYMM(date)
          ORDER BY (domain, date)
          SETTINGS index_granularity = 8192;
  ```
  </details>
- 키(도메인, 날짜)가 같다면 자동 합계되지만 백그라운드에서 주기적으로 동작하기에 sum(access) as dau 등의 aggregation은 필요합니다.



- 캐시를 하루 단위(86400)초로 수정하였으나 브라우저에서 실제로 잘 동작할지는 배포 후 실험해봐야 알 것 같습니다.

### 📷 스크린샷 또는 GIF

![Screen Recording 2024-11-19 at 9 46 19 PM](https://github.com/user-attachments/assets/0bca86a6-5a3c-48b2-af7e-9c85d0383a41)
