### PR TITLE
[BE] 개별 프로젝트 날짜별 DAU(일일 활성 사용자) API 구현

### DIFF
--- a/backend/console-server/src/log/dto/get-dau-by-project-response.dto.ts
+++ b/backend/console-server/src/log/dto/get-dau-by-project-response.dto.ts
@@ -1,0 +1,27 @@
+import { Exclude, Expose, Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+@Exclude()
+export class GetDAUByProjectResponseDto {
+    @ApiProperty({
+        example: 'my-project',
+        description: '프로젝트 이름',
+    })
+    @Expose()
+    projectName: string;
+
+    @ApiProperty({
+        example: '2023-10-01',
+        description: '조회한 날짜',
+    })
+    @Expose()
+    date: string;
+
+    @ApiProperty({
+        example: 12345,
+        description: '해당 날짜의 DAU 값',
+    })
+    @Expose()
+    @Type(() => Number)
+    dau: number;
+}

--- a/backend/console-server/src/log/dto/get-dau-by-project.dto.ts
+++ b/backend/console-server/src/log/dto/get-dau-by-project.dto.ts
@@ -1,0 +1,20 @@
+import { IsNotEmpty, IsString, IsDateString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetDAUByProjectDto {
+    @ApiProperty({
+        example: 'watchducks',
+        description: '프로젝트 이름',
+    })
+    @IsNotEmpty()
+    @IsString()
+    projectName: string;
+
+    @ApiProperty({
+        example: '2023-10-01',
+        description: '조회할 날짜 (YYYY-MM-DD 형식)',
+    })
+    @IsNotEmpty()
+    @IsDateString()
+    date: string;
+}

--- a/backend/console-server/src/log/log.contorller.spec.ts
+++ b/backend/console-server/src/log/log.contorller.spec.ts
@@ -21,6 +21,7 @@ describe('LogController 테스트', () => {
         trafficByGeneration: jest.fn(),
         getPathSpeedRankByProject: jest.fn(),
         getTrafficByProject: jest.fn(),
+        getDAUByProject: jest.fn(),
     };
 
     beforeEach(async () => {
@@ -248,6 +249,38 @@ describe('LogController 테스트', () => {
             expect(result.trafficData).toHaveLength(0);
             expect(service.getTrafficByProject).toHaveBeenCalledWith(mockRequestDto);
             expect(service.getTrafficByProject).toHaveBeenCalledTimes(1);
+        });
+    });
+    describe('getDAUByProject()는', () => {
+        const mockRequestDto = { projectName: 'example-project', date: '2024-11-01' };
+
+        const mockResponseDto = {
+            projectName: 'example-project',
+            date: '2024-11-01',
+            dau: 125,
+        };
+
+        it('프로젝트명과 날짜가 들어왔을 때 DAU 데이터를 반환해야 한다', async () => {
+            mockLogService.getDAUByProject.mockResolvedValue(mockResponseDto);
+
+            const result = await controller.getDAUByProject(mockRequestDto);
+
+            expect(result).toEqual(mockResponseDto);
+            expect(result).toHaveProperty('projectName', mockRequestDto.projectName);
+            expect(result).toHaveProperty('date', mockRequestDto.date);
+            expect(result).toHaveProperty('dau', 125);
+            expect(service.getDAUByProject).toHaveBeenCalledWith(mockRequestDto);
+            expect(service.getDAUByProject).toHaveBeenCalledTimes(1);
+        });
+
+        it('서비스 에러 시 예외를 throw 해야 한다', async () => {
+            const error = new Error('Database error');
+            mockLogService.getDAUByProject.mockRejectedValue(error);
+
+            await expect(controller.getDAUByProject(mockRequestDto)).rejects.toThrow(error);
+
+            expect(service.getDAUByProject).toHaveBeenCalledWith(mockRequestDto);
+            expect(service.getDAUByProject).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/backend/console-server/src/log/log.controller.ts
+++ b/backend/console-server/src/log/log.controller.ts
@@ -6,6 +6,8 @@ import { GetPathSpeedRankDto } from './dto/get-path-speed-rank.dto';
 import { GetPathSpeedRankResponseDto } from './dto/get-path-speed-rank-response.dto';
 import { GetTrafficByProjectResponseDto } from './dto/get-traffic-by-project-response.dto';
 import { GetTrafficByProjectDto } from './dto/get-traffic-by-project.dto';
+import { GetDAUByProjectResponseDto } from './dto/get-dau-by-project-response.dto';
+import { GetDAUByProjectDto } from './dto/get-dau-by-project.dto';
 
 @Controller('log')
 export class LogController {
@@ -105,5 +107,20 @@ export class LogController {
     })
     async getPathSpeedRankByProject(@Query() getPathSpeedRankDto: GetPathSpeedRankDto) {
         return await this.logService.getPathSpeedRankByProject(getPathSpeedRankDto);
+    }
+
+    @Get('/dau')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: '프로젝트별 DAU 조회',
+        description: '프로젝트 이름과 날짜로 해당 프로젝트의 DAU를 반환합니다.',
+    })
+    @ApiResponse({
+        status: HttpStatus.OK,
+        description: '프로젝트의 DAU가 정상적으로 반환됨.',
+        type: GetDAUByProjectResponseDto,
+    })
+    async getDAUByProject(@Query() getDAUByProjectDto: GetDAUByProjectDto) {
+        return await this.logService.getDAUByProject(getDAUByProjectDto);
     }
 }

--- a/backend/console-server/src/log/log.repository.spec.ts
+++ b/backend/console-server/src/log/log.repository.spec.ts
@@ -244,4 +244,69 @@ describe('LogRepository 테스트', () => {
             );
         });
     });
+
+    describe('getDAUByProject()', () => {
+        const domain = 'example.com';
+        const date = '2024-11-18';
+
+        it('존재하는 도메인과 날짜가 들어오면 존재하는 DAU 값을 반환해야 한다.', async () => {
+            const mockResult = [{ dau: 150 }];
+            mockClickhouse.query.mockResolvedValue(mockResult);
+
+            const result = await repository.getDAUByProject(domain, date);
+
+            expect(result).toBe(150);
+            expect(clickhouse.query).toHaveBeenCalledWith(
+                expect.stringMatching(
+                    /SELECT.*SUM\(access\).*as dau.*FROM dau.*WHERE.*domain = \{domain:String}.*AND.*date = \{date:String}/s,
+                ),
+                expect.objectContaining({ domain, date }),
+            );
+        });
+
+        it('DAU 데이터가 없을 경우 0을 반환해야 한다.', async () => {
+            mockClickhouse.query.mockResolvedValue([]);
+
+            const result = await repository.getDAUByProject(domain, date);
+
+            expect(result).toBe(0);
+            expect(clickhouse.query).toHaveBeenCalledWith(
+                expect.stringMatching(
+                    /SELECT.*SUM\(access\).*as dau.*FROM dau.*WHERE.*domain = \{domain:String}.*AND.*date = \{date:String}/s,
+                ),
+                expect.objectContaining({ domain, date }),
+            );
+        });
+
+        it('DAU 값이 null일 경우 0을 반환해야 한다.', async () => {
+            const mockResult = [{ dau: null }];
+            mockClickhouse.query.mockResolvedValue(mockResult);
+
+            const result = await repository.getDAUByProject(domain, date);
+
+            expect(result).toBe(0);
+            expect(clickhouse.query).toHaveBeenCalledWith(
+                expect.stringMatching(
+                    /SELECT.*SUM\(access\).*as dau.*FROM dau.*WHERE.*domain = \{domain:String}.*AND.*date = \{date:String}/s,
+                ),
+                expect.objectContaining({ domain, date }),
+            );
+        });
+
+        it('Clickhouse 호출 중 에러가 발생하면 예외를 throw 해야 한다.', async () => {
+            const error = new Error('Clickhouse query failed');
+            mockClickhouse.query.mockRejectedValue(error);
+
+            await expect(repository.getDAUByProject(domain, date)).rejects.toThrow(
+                'Clickhouse query failed',
+            );
+
+            expect(clickhouse.query).toHaveBeenCalledWith(
+                expect.stringMatching(
+                    /SELECT.*SUM\(access\).*as dau.*FROM dau.*WHERE.*domain = \{domain:String}.*AND.*date = \{date:String}/s,
+                ),
+                expect.objectContaining({ domain, date }),
+            );
+        });
+    });
 });

--- a/backend/console-server/src/log/log.repository.ts
+++ b/backend/console-server/src/log/log.repository.ts
@@ -112,7 +112,7 @@ export class LogRepository {
     }
 
     async getTrafficByProject(domain: string, timeUnit: string) {
-        const queryBuilder = new TimeSeriesQueryBuilder()
+        const { query, params } = new TimeSeriesQueryBuilder()
             .metrics([
                 { name: '*', aggregation: 'count' },
                 { name: `toStartOf${timeUnit}(timestamp) as timestamp` },
@@ -123,6 +123,20 @@ export class LogRepository {
             .orderBy(['timestamp'], false)
             .build();
 
-        return await this.clickhouse.query(queryBuilder.query, queryBuilder.params);
+        return await this.clickhouse.query(query, params);
+    }
+
+    async getDAUByProject(domain: string, date: string) {
+        const { query, params } = new TimeSeriesQueryBuilder()
+            .metrics([{ name: `SUM(access) as dau` }])
+            .from('dau')
+            .filter({ domain: domain, date: date })
+            .build();
+        const result = await this.clickhouse.query<{ dau: number }>(query, params);
+        if (result.length > 0 && result[0].dau !== null) {
+            return result[0].dau;
+        } else {
+            return 0;
+        }
     }
 }

--- a/backend/console-server/src/log/log.service.spec.ts
+++ b/backend/console-server/src/log/log.service.spec.ts
@@ -18,6 +18,7 @@ describe('LogService 테스트', () => {
         findTrafficByGeneration: jest.fn(),
         getPathSpeedRankByProject: jest.fn(),
         getTrafficByProject: jest.fn(),
+        getDAUByProject: jest.fn(),
     };
 
     beforeEach(async () => {
@@ -318,6 +319,97 @@ describe('LogService 테스트', () => {
                 timeUnit: mockRequestDto.timeUnit,
                 trafficData: [],
             });
+        });
+    });
+
+    describe('getDAUByProject()는', () => {
+        const mockRequestDto = { projectName: 'example-project', date: '2024-11-01' };
+        const mockProject = {
+            name: 'example-project',
+            domain: 'example.com',
+        };
+        const mockDAUData = 125;
+        const mockResponseDto = {
+            projectName: 'example-project',
+            date: '2024-11-01',
+            dau: 125,
+        };
+
+        it('프로젝트명으로 도메인을 조회한 후 날짜에 따른 DAU 데이터를 반환해야 한다', async () => {
+            const projectRepository = service['projectRepository'];
+            projectRepository.findOne = jest.fn().mockResolvedValue(mockProject);
+
+            mockLogRepository.getDAUByProject = jest.fn().mockResolvedValue(mockDAUData);
+
+            const result = await service.getDAUByProject(mockRequestDto);
+
+            expect(projectRepository.findOne).toHaveBeenCalledWith({
+                where: { name: mockRequestDto.projectName },
+                select: ['domain'],
+            });
+            expect(mockLogRepository.getDAUByProject).toHaveBeenCalledWith(
+                mockProject.domain,
+                mockRequestDto.date,
+            );
+            expect(result).toEqual(mockResponseDto);
+        });
+
+        it('존재하지 않는 프로젝트명을 조회할 경우 NotFoundException을 던져야 한다', async () => {
+            const projectRepository = service['projectRepository'];
+            projectRepository.findOne = jest.fn().mockResolvedValue(null);
+
+            await expect(service.getDAUByProject(mockRequestDto)).rejects.toThrow(
+                new NotFoundException(`Project with name ${mockRequestDto.projectName} not found`),
+            );
+
+            expect(projectRepository.findOne).toHaveBeenCalledWith({
+                where: { name: mockRequestDto.projectName },
+                select: ['domain'],
+            });
+            expect(mockLogRepository.getDAUByProject).not.toHaveBeenCalled();
+        });
+
+        it('존재하는 프로젝트에 DAU 데이터가 없을 경우 0으로 반환해야 한다', async () => {
+            const projectRepository = service['projectRepository'];
+            projectRepository.findOne = jest.fn().mockResolvedValue(mockProject);
+
+            mockLogRepository.getDAUByProject = jest.fn().mockResolvedValue(0);
+
+            const result = await service.getDAUByProject(mockRequestDto);
+
+            expect(projectRepository.findOne).toHaveBeenCalledWith({
+                where: { name: mockRequestDto.projectName },
+                select: ['domain'],
+            });
+            expect(mockLogRepository.getDAUByProject).toHaveBeenCalledWith(
+                mockProject.domain,
+                mockRequestDto.date,
+            );
+            expect(result).toEqual({
+                projectName: mockRequestDto.projectName,
+                date: mockRequestDto.date,
+                dau: 0,
+            });
+        });
+
+        it('로그 레포지토리 호출 중 에러가 발생할 경우 예외를 던져야 한다', async () => {
+            const projectRepository = service['projectRepository'];
+            projectRepository.findOne = jest.fn().mockResolvedValue(mockProject);
+
+            mockLogRepository.getDAUByProject = jest
+                .fn()
+                .mockRejectedValue(new Error('Database error'));
+
+            await expect(service.getDAUByProject(mockRequestDto)).rejects.toThrow('Database error');
+
+            expect(projectRepository.findOne).toHaveBeenCalledWith({
+                where: { name: mockRequestDto.projectName },
+                select: ['domain'],
+            });
+            expect(mockLogRepository.getDAUByProject).toHaveBeenCalledWith(
+                mockProject.domain,
+                mockRequestDto.date,
+            );
         });
     });
 });

--- a/backend/console-server/src/log/log.service.ts
+++ b/backend/console-server/src/log/log.service.ts
@@ -8,6 +8,8 @@ import { GetPathSpeedRankDto } from './dto/get-path-speed-rank.dto';
 import { GetPathSpeedRankResponseDto } from './dto/get-path-speed-rank-response.dto';
 import { GetTrafficByProjectDto } from './dto/get-traffic-by-project.dto';
 import { GetTrafficByProjectResponseDto } from './dto/get-traffic-by-project-response.dto';
+import { GetDAUByProjectDto } from './dto/get-dau-by-project.dto';
+import { GetDAUByProjectResponseDto } from './dto/get-dau-by-project-response.dto';
 
 @Injectable()
 export class LogService {
@@ -80,6 +82,24 @@ export class LogService {
             projectName,
             timeUnit,
             trafficData,
+        });
+    }
+
+    async getDAUByProject(getDAUByProjectDto: GetDAUByProjectDto) {
+        const { projectName, date } = getDAUByProjectDto;
+
+        const project = await this.projectRepository.findOne({
+            where: { name: projectName },
+            select: ['domain'],
+        });
+        if (!project) {
+            throw new NotFoundException(`Project with name ${projectName} not found`);
+        }
+        const dau = await this.logRepository.getDAUByProject(project.domain, date);
+        return plainToInstance(GetDAUByProjectResponseDto, {
+            projectName,
+            date,
+            dau,
         });
     }
 }

--- a/backend/name-server/src/server/server.ts
+++ b/backend/name-server/src/server/server.ts
@@ -35,7 +35,9 @@ export class Server {
             const question = this.parseQuery(query);
             logger.logQuery(question.name, remoteInfo);
             await this.validateRequest(question.name);
-            await this.dauRecorder.recordAccess(question.name);
+            this.dauRecorder.recordAccess(question.name).catch((err) => {
+                logger.error(`DAU recording failed for ${question.name}: ${err.message}`);
+            });
 
             const response = new DNSResponseBuilder(this.config, query)
                 .addAnswer(ResponseCode.NOERROR, question)


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
- #16 
- #111 (선행 태스크)
- #112 (본 태스크)

### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
- DTO 구현
  - [x] GetDAUByProjectDto: 클라이언트 요청을 위한 DTO
  - [x] GetDAUByProjectResponseDto: API 응답을 위한 DTO
- LogController
  - [x] getDAUByProject 메소드 추가
  - [x] @Query로 프로젝트명과 날짜를 받아 DAU 데이터를 반환
- LogService
  - [x] getDAUByProject 메소드 구현
  - [x] projectRepository를 이용해 프로젝트 도메인 조회
  - [x] logRepository에서 DAU 데이터 조회
- LogRepository
  - [x] Clickhouse 쿼리를 사용하여 프로젝트 도메인 및 날짜를 기준으로 DAU 데이터 조회
- 테스트 코드
  - [x] LogController, LogService, LogRepository 각각에 대한 유닛 테스트 추가
  - [x] 다양한 시나리오(성공, 데이터 없음, 에러 발생 등)를 테스트

### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->


### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->


### 📷 스크린샷 또는 GIF
- api 실행 결과
  ![Screen Recording 2024-11-20 at 12 02 49 AM](https://github.com/user-attachments/assets/4de5819e-cc97-48a2-abd3-2e5b012ad8ea)
- 테스트 결과
  - LogRepository 테스트
    - getDAUByProject()
        ✓ 존재하는 도메인과 날짜가 들어오면 존재하는 DAU 값을 반환해야 한다. (1 ms)
        ✓ DAU 데이터가 없을 경우 0을 반환해야 한다. (1 ms)
        ✓ DAU 값이 null일 경우 0을 반환해야 한다. (1 ms)
        ✓ Clickhouse 호출 중 에러가 발생하면 예외를 throw 해야 한다. (2 ms)
  
  
  - LogService 테스트
    - getDAUByProject()는
        ✓ 프로젝트명으로 도메인을 조회한 후 날짜에 따른 DAU 데이터를 반환해야 한다 (1 ms)
        ✓ 존재하지 않는 프로젝트명을 조회할 경우 NotFoundException을 던져야 한다
        ✓ 존재하는 프로젝트에 DAU 데이터가 없을 경우 0으로 반환해야 한다 (1 ms)
        ✓ 로그 레포지토리 호출 중 에러가 발생할 경우 예외를 던져야 한다 (2 ms)
  
  - LogController 테스트
    - getDAUByProject()는
        ✓ 프로젝트명과 날짜가 들어왔을 때 DAU 데이터를 반환해야 한다 (1 ms)
        ✓ 서비스 에러 시 예외를 throw 해야 한다
