### PR TITLE
[BE] repository 매핑 방식 개선 및 동작하지 않던 api 수정 (+ swagger 문서화 알맞게 수정)

### DIFF
--- a/backend/console-server/src/clickhouse/clickhouse.ts
+++ b/backend/console-server/src/clickhouse/clickhouse.ts
@@ -87,13 +87,14 @@ export class Clickhouse implements OnModuleInit, OnModuleDestroy {
         return new Promise((resolve) => setTimeout(resolve, ms));
     }
 
-    async query<T>(query: string, params?: Record<string, unknown>): Promise<T[]> {
+    async query<T extends object>(query: string, params?: Record<string, unknown>): Promise<T[]> {
         try {
             const resultSet = await this.client.query({
                 query,
                 format: 'JSONEachRow',
                 query_params: params,
             });
+
             return await resultSet.json<T>();
         } catch (error) {
             this.logger.error(`Query failed: ${error.message}`);

--- a/backend/console-server/src/log/dto/get-avg-elapsed-time-response.dto.ts
+++ b/backend/console-server/src/log/dto/get-avg-elapsed-time-response.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+
+export class GetAvgElapsedTimeResponseDto {
+    @ApiProperty({
+        example: '35.353',
+        description: '해당 기수의 전체 트래픽 평균 응답시간',
+    })
+    @Expose()
+    avgResponseTime: number;
+}

--- a/backend/console-server/src/log/dto/get-path-speed-rank-response.dto.ts
+++ b/backend/console-server/src/log/dto/get-path-speed-rank-response.dto.ts
@@ -1,7 +1,7 @@
 import { Exclude, Expose, Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
 
-class PathResponseDto {
+export class ResponseTimeByPath {
     @ApiProperty({
         example: '/api/v1/resource',
         description: '사용자의 요청 경로',
@@ -14,7 +14,7 @@ class PathResponseDto {
         description: '해당 경로의 평균 응답 소요 시간 (ms).',
     })
     @Expose()
-    avg_elapsed_time: number;
+    avgResponseTime: number;
 }
 
 @Exclude()
@@ -27,18 +27,18 @@ export class GetPathSpeedRankResponseDto {
     projectName: string;
 
     @ApiProperty({
-        type: [PathResponseDto],
+        type: [ResponseTimeByPath],
         description: '프로젝트의 가장 빠른 응답 경로 배열',
     })
     @Expose()
-    @Type(() => PathResponseDto)
-    fastestPaths: Array<PathResponseDto>;
+    @Type(() => ResponseTimeByPath)
+    fastestPaths: ResponseTimeByPath[];
 
     @ApiProperty({
-        type: [PathResponseDto],
+        type: [ResponseTimeByPath],
         description: '프로젝트의 가장 느린 응답 경로 배열',
     })
     @Expose()
-    @Type(() => PathResponseDto)
-    slowestPaths: Array<PathResponseDto>;
+    @Type(() => ResponseTimeByPath)
+    slowestPaths: ResponseTimeByPath[];
 }

--- a/backend/console-server/src/log/dto/get-path-speed-rank.dto.ts
+++ b/backend/console-server/src/log/dto/get-path-speed-rank.dto.ts
@@ -1,7 +1,13 @@
 import { IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class GetPathSpeedRankDto {
     @IsNotEmpty()
     @IsString()
+    @ApiProperty({
+        description: '프로젝트명',
+        example: 'watchducks',
+        required: true,
+    })
     projectName: string;
 }

--- a/backend/console-server/src/log/dto/get-success-rate-by-project-response.dto.ts
+++ b/backend/console-server/src/log/dto/get-success-rate-by-project-response.dto.ts
@@ -1,7 +1,7 @@
 import { Expose, Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
 
-export class GetSuccessRateByProjectResponseDTO {
+export class GetSuccessRateByProjectResponseDto {
     @ApiProperty({
         description: '프로젝트의 이름',
         example: 'watchducks',

--- a/backend/console-server/src/log/dto/get-traffic-by-generation-response.dto.ts
+++ b/backend/console-server/src/log/dto/get-traffic-by-generation-response.dto.ts
@@ -3,7 +3,7 @@ import { Expose } from 'class-transformer';
 
 export class GetTrafficByGenerationResponseDto {
     @ApiProperty({
-        example: 15,
+        example: 1500,
         description: '기수 별 트래픽 수',
         type: Number,
     })

--- a/backend/console-server/src/log/dto/get-traffic-by-project-response.dto.ts
+++ b/backend/console-server/src/log/dto/get-traffic-by-project-response.dto.ts
@@ -1,7 +1,7 @@
 import { Expose, Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
 
-class TrafficDataPoint {
+export class TrafficCountByTimeunit {
     @ApiProperty({
         example: '2024-11-07 23:07:28',
         description: '시간 단위 별 타임스탬프',
@@ -34,10 +34,10 @@ export class GetTrafficByProjectResponseDto {
     timeUnit: string;
 
     @ApiProperty({
-        type: [TrafficDataPoint],
+        type: [TrafficCountByTimeunit],
         description: '시간 단위 별 트래픽 데이터',
     })
     @Expose()
-    @Type(() => TrafficDataPoint)
-    trafficData: TrafficDataPoint[];
+    @Type(() => TrafficCountByTimeunit)
+    trafficData: TrafficCountByTimeunit[];
 }

--- a/backend/console-server/src/log/dto/get-traffic-rank-response.dto.ts
+++ b/backend/console-server/src/log/dto/get-traffic-rank-response.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { TrafficRankMetric } from '../metric/traffic-rank.metric';
+
+export class GetTrafficRankResponseDto {
+    @ApiProperty({
+        example: [
+            { host: 'watchducks01', count: 100 },
+            { host: 'watchducks02', count: 99 },
+            { host: 'watchducks03', count: 98 },
+            { host: 'watchducks04', count: 97 },
+            { host: 'watchducks05', count: 96 },
+        ],
+        description: '트래픽 수가 가장 많은 Top5 호스트, 트래픽 수',
+    })
+    @Expose()
+    rank: TrafficRankMetric[];
+}

--- a/backend/console-server/src/log/log.contorller.spec.ts
+++ b/backend/console-server/src/log/log.contorller.spec.ts
@@ -46,32 +46,6 @@ describe('LogController 테스트', () => {
         expect(controller).toBeDefined();
     });
 
-    describe('httpLog는 ', () => {
-        const mockResult = [
-            {
-                date: '2024-11-18',
-                avg_elapsed_time: 100,
-                request_count: 1000,
-            },
-        ];
-
-        it('HTTP 로그 데이터를 반환해야 한다', async () => {
-            mockLogService.httpLog.mockResolvedValue(mockResult);
-
-            const result = await controller.httpLog();
-
-            expect(result).toEqual(mockResult);
-            expect(service.httpLog).toHaveBeenCalledTimes(1);
-        });
-
-        it('서비스 에러 시 예외를 throw 해야 한다', async () => {
-            const error = new Error('Database error');
-            mockLogService.httpLog.mockRejectedValue(error);
-
-            await expect(controller.httpLog()).rejects.toThrow(error);
-        });
-    });
-
     describe('elapsedTime()은 ', () => {
         const mockResult = {
             status: HttpStatus.OK,
@@ -86,7 +60,7 @@ describe('LogController 테스트', () => {
             expect(result).toEqual(mockResult);
             expect(result).toHaveProperty('status', HttpStatus.OK);
             expect(result).toHaveProperty('data.avg_elapsed_time');
-            expect(service.elapsedTime).toHaveBeenCalledTimes(1);
+            expect(service.getAvgElapsedTime).toHaveBeenCalledTimes(1);
         });
     });
 
@@ -110,7 +84,7 @@ describe('LogController 테스트', () => {
             expect(result).toEqual(mockResult);
             expect(result).toHaveProperty('status', HttpStatus.OK);
             expect(result.data).toHaveLength(5);
-            expect(service.trafficRank).toHaveBeenCalledTimes(1);
+            expect(service.getTrafficRank).toHaveBeenCalledTimes(1);
 
             const sortedData = [...result.data].sort((a, b) => b.count - a.count);
             expect(result.data).toEqual(sortedData);

--- a/backend/console-server/src/log/log.controller.ts
+++ b/backend/console-server/src/log/log.controller.ts
@@ -12,17 +12,14 @@ import { GetSuccessRateResponseDto } from './dto/get-success-rate-response.dto';
 import { GetSuccessRateDto } from './dto/get-success-rate.dto';
 import { GetTrafficByGenerationDto } from './dto/get-traffic-by-generation.dto';
 import { GetSuccessRateByProjectDto } from './dto/get-success-rate-by-project.dto';
-
+import { GetAvgElapsedTimeResponseDto } from './dto/get-avg-elapsed-time-response.dto';
+import { GetTrafficRankResponseDto } from './dto/get-traffic-rank-response.dto';
+import { GetTrafficByGenerationResponseDto } from './dto/get-traffic-by-generation-response.dto';
+import { GetSuccessRateByProjectResponseDto } from './dto/get-success-rate-by-project-response.dto';
 
 @Controller('log')
 export class LogController {
     constructor(private readonly logService: LogService) {}
-
-    @Get()
-    @HttpCode(HttpStatus.OK)
-    async httpLog() {
-        return await this.logService.httpLog();
-    }
 
     @Get('/elapsed-time')
     @HttpCode(HttpStatus.OK)
@@ -31,12 +28,12 @@ export class LogController {
         description: '요청받은 기수의 트래픽에 대한 평균 응답시간을 반환합니다.',
     })
     @ApiResponse({
-        status: 200,
+        status: HttpStatus.OK,
         description: '평균 응답시간이 성공적으로 반환됨.',
-        type: ProjectResponseDto,
+        type: GetAvgElapsedTimeResponseDto,
     })
     async elapsedTime() {
-        return await this.logService.elapsedTime();
+        return await this.logService.getAvgElapsedTime();
     }
 
     @Get('/traffic/rank')
@@ -46,12 +43,12 @@ export class LogController {
         description: '요청받은 기수의 트래픽 랭킹 TOP 5를 반환합니다.',
     })
     @ApiResponse({
-        status: 200,
+        status: HttpStatus.OK,
         description: '트래픽 랭킹 TOP 5가 정상적으로 반환됨.',
-        type: ProjectResponseDto,
+        type: GetTrafficRankResponseDto,
     })
     async trafficRank() {
-        return await this.logService.trafficRank();
+        return await this.logService.getTrafficRank();
     }
 
     @Get('/success-rate')
@@ -61,7 +58,7 @@ export class LogController {
         description: '요청받은 기수의 기수 내 응답 성공률를 반환합니다.',
     })
     @ApiResponse({
-        status: 200,
+        status: HttpStatus.OK,
         description: '기수 내 응답 성공률이 성공적으로 반환됨.',
         type: GetSuccessRateResponseDto,
     })
@@ -73,12 +70,12 @@ export class LogController {
     @HttpCode(HttpStatus.OK)
     @ApiOperation({
         summary: '프로젝트 별 응답 성공률',
-        description: '요청받은 프로젝트의 응답 성공률을 성공적으로 반환합니다.',
+        description: '요청받은 프로젝트의 응답 성공률을 반환합니다.',
     })
     @ApiResponse({
-        status: 200,
+        status: HttpStatus.OK,
         description: '프로젝트 별 응답 성공률이 성공적으로 반환됨.',
-        type: GetSuccessRateByProjectDto,
+        type: GetSuccessRateByProjectResponseDto,
     })
     async getResponseSuccessRateByProject(
         @Query() getSuccessRateByProjectDto: GetSuccessRateByProjectDto,
@@ -93,7 +90,7 @@ export class LogController {
         description: '프로젝트 이름과 시간 단위로 특정 프로젝트의 트래픽 데이터를 반환합니다.',
     })
     @ApiResponse({
-        status: 200,
+        status: HttpStatus.OK,
         description: '특정 프로젝트의 트래픽 데이터가 반환됨.',
         type: GetTrafficByProjectResponseDto,
     })
@@ -108,9 +105,9 @@ export class LogController {
         description: ' 요청받은 기수의 기수 내 총 트래픽를 반환합니다.',
     })
     @ApiResponse({
-        status: 200,
-        description: '기수 내 총 트래픽가 정상적으로 반환됨.',
-        type: GetTrafficByProjectResponseDto,
+        status: HttpStatus.OK,
+        description: '기수 내 총 트래픽이 정상적으로 반환됨.',
+        type: GetTrafficByGenerationResponseDto,
     })
     async getTrafficByGeneration(@Query() getTrafficByGenerationDto: GetTrafficByGenerationDto) {
         return await this.logService.getTrafficByGeneration(getTrafficByGenerationDto);
@@ -128,6 +125,7 @@ export class LogController {
         type: GetPathSpeedRankResponseDto,
     })
     async getPathSpeedRankByProject(@Query() getPathSpeedRankDto: GetPathSpeedRankDto) {
+
         return await this.logService.getPathSpeedRankByProject(getPathSpeedRankDto);
     }
 

--- a/backend/console-server/src/log/log.repository.spec.ts
+++ b/backend/console-server/src/log/log.repository.spec.ts
@@ -34,43 +34,6 @@ describe('LogRepository 테스트', () => {
         expect(repository).toBeDefined();
     });
 
-    describe('findHttpLog()는 ', () => {
-        it('요구 받은 조건의 트래픽 정보를 반환한다.', async () => {
-            const mockResult = [
-                {
-                    date: '2024-11-18',
-                    avg_elapsed_time: 100,
-                    request_count: 1000,
-                },
-            ];
-            mockClickhouse.query.mockResolvedValue(mockResult);
-
-            const result = await repository.findHttpLog();
-
-            expect(result).toEqual(mockResult);
-            expect(clickhouse.query).toHaveBeenCalledWith(
-                expect.stringMatching(
-                    /SELECT.*toDate\(timestamp\).*FROM http_log.*GROUP BY date.*ORDER BY date/s,
-                ),
-            );
-        });
-
-        it('결과가 없을 경우 빈 배열을 반환해야 한다.', async () => {
-            mockClickhouse.query.mockResolvedValue([]);
-
-            const result = await repository.findHttpLog();
-
-            expect(result).toEqual([]);
-        });
-
-        it('clickhouse 에러 발생시 예외를 throw 해야 한다.', async () => {
-            const error = new Error('Clickhouse connection error');
-            mockClickhouse.query.mockRejectedValue(error);
-
-            await expect(repository.findHttpLog()).rejects.toThrow('Clickhouse connection error');
-        });
-    });
-
     describe('findAvgElapsedTime()는 ', () => {
         it('TimeSeriesQueryBuilder를 사용하여 올바른 쿼리를 생성해야 한다.', async () => {
             const mockResult = [{ avg_elapsed_time: 150 }];
@@ -94,7 +57,7 @@ describe('LogRepository 테스트', () => {
             ];
             mockClickhouse.query.mockResolvedValue(mockResult);
 
-            const result = await repository.findCountByHost();
+            const result = await repository.findTop5CountByHost();
 
             expect(result).toEqual(mockResult);
             expect(clickhouse.query).toHaveBeenCalledWith(
@@ -197,7 +160,7 @@ describe('LogRepository 테스트', () => {
                 .mockResolvedValueOnce(mockFastestPaths)
                 .mockResolvedValueOnce(mockSlowestPaths);
 
-            const result = await repository.getPathSpeedRankByProject(domain);
+            const result = await repository.getFastestPathsByDomain(domain);
 
             expect(result).toEqual({
                 fastestPaths: mockFastestPaths,
@@ -225,7 +188,7 @@ describe('LogRepository 테스트', () => {
             const error = new Error('Clickhouse query failed');
             mockClickhouse.query.mockRejectedValue(error);
 
-            await expect(repository.getPathSpeedRankByProject(domain)).rejects.toThrow(
+            await expect(repository.getFastestPathsByDomain(domain)).rejects.toThrow(
                 'Clickhouse query failed',
             );
         });

--- a/backend/console-server/src/log/log.service.spec.ts
+++ b/backend/console-server/src/log/log.service.spec.ts
@@ -7,7 +7,7 @@ import { Project } from '../project/entities/project.entity';
 import { NotFoundException } from '@nestjs/common';
 import type { GetTrafficByGenerationResponseDto } from './dto/get-traffic-by-generation-response.dto';
 import { GetTrafficByGenerationDto } from './dto/get-traffic-by-generation.dto';
-import { GetSuccessRateByProjectResponseDTO } from './dto/get-success-rate-by-project-response.dto';
+import { GetSuccessRateByProjectResponseDto } from './dto/get-success-rate-by-project-response.dto';
 
 describe('LogService 테스트', () => {
     let service: LogService;
@@ -50,38 +50,12 @@ describe('LogService 테스트', () => {
         expect(service).toBeDefined();
     });
 
-    describe('httpLog()는 ', () => {
-        it('레포지토리에서 로그를 올바르게 반환할 수 있어야 있다.', async () => {
-            const mockLogs = [{ date: '2024-03-01', avg_elapsed_time: 100, request_count: 1000 }];
-            mockLogRepository.findHttpLog.mockResolvedValue(mockLogs);
-
-            const result = await service.httpLog();
-
-            expect(result).toEqual(mockLogs);
-            expect(repository.findHttpLog).toHaveBeenCalled();
-        });
-
-        it('빈 결과를 잘 처리할 수 있어야 한다.', async () => {
-            mockLogRepository.findHttpLog.mockResolvedValue([]);
-
-            const result = await service.httpLog();
-
-            expect(result).toEqual([]);
-        });
-
-        it('레포지토리 에러를 처리할 수 있어야 한다.', async () => {
-            mockLogRepository.findHttpLog.mockRejectedValue(new Error('Database error'));
-
-            await expect(service.httpLog()).rejects.toThrow('Database error');
-        });
-    });
-
     describe('elapsedTime()는 ', () => {
         it('평균 응답 시간을 반환할 수 있어야 한다.', async () => {
             const mockTime = { avg_elapsed_time: 150 };
             mockLogRepository.findAvgElapsedTime.mockResolvedValue(mockTime);
 
-            const result = await service.elapsedTime();
+            const result = await service.getAvgElapsedTime();
 
             expect(result).toEqual(mockTime);
             expect(repository.findAvgElapsedTime).toHaveBeenCalled();
@@ -100,11 +74,11 @@ describe('LogService 테스트', () => {
             ];
             mockLogRepository.findCountByHost.mockResolvedValue(mockRanks);
 
-            const result = await service.trafficRank();
+            const result = await service.getTrafficRank();
 
             expect(result).toHaveLength(5);
             expect(result).toEqual(mockRanks.slice(0, 5));
-            expect(repository.findCountByHost).toHaveBeenCalled();
+            expect(repository.findTop5CountByHost).toHaveBeenCalled();
         });
 
         it('5개 이하의 결과에 대해서 올바르게 처리할 수 있어야 한다.', async () => {
@@ -114,7 +88,7 @@ describe('LogService 테스트', () => {
             ];
             mockLogRepository.findCountByHost.mockResolvedValue(mockRanks);
 
-            const result = await service.trafficRank();
+            const result = await service.getTrafficRank();
 
             expect(result).toHaveLength(2);
             expect(result).toEqual(mockRanks);
@@ -175,7 +149,7 @@ describe('LogService 테스트', () => {
 
             const result = await service.getResponseSuccessRateByProject(mockRequestDto);
 
-            expect(result).toBeInstanceOf(GetSuccessRateByProjectResponseDTO);
+            expect(result).toBeInstanceOf(GetSuccessRateByProjectResponseDto);
             expect(Object.keys(result)).toContain('projectName');
             expect(Object.keys(result)).toContain('success_rate');
             expect(Object.keys(result).length).toBe(2);

--- a/backend/console-server/src/log/log.service.ts
+++ b/backend/console-server/src/log/log.service.ts
@@ -5,16 +5,25 @@ import { Project } from '../project/entities/project.entity';
 import { Repository } from 'typeorm';
 import { LogRepository } from './log.repository';
 import { GetPathSpeedRankDto } from './dto/get-path-speed-rank.dto';
-import { GetPathSpeedRankResponseDto } from './dto/get-path-speed-rank-response.dto';
+import {
+    GetPathSpeedRankResponseDto,
+    ResponseTimeByPath,
+} from './dto/get-path-speed-rank-response.dto';
 import { GetTrafficByProjectDto } from './dto/get-traffic-by-project.dto';
-import { GetTrafficByProjectResponseDto } from './dto/get-traffic-by-project-response.dto';
+import {
+    GetTrafficByProjectResponseDto,
+    TrafficCountByTimeunit,
+} from './dto/get-traffic-by-project-response.dto';
 import { GetDAUByProjectDto } from './dto/get-dau-by-project.dto';
 import { GetDAUByProjectResponseDto } from './dto/get-dau-by-project-response.dto';
 import { GetSuccessRateResponseDto } from './dto/get-success-rate-response.dto';
 import { GetSuccessRateDto } from './dto/get-success-rate.dto';
 import { GetTrafficByGenerationDto } from './dto/get-traffic-by-generation.dto';
-import { GetSuccessRateByProjectResponseDTO } from './dto/get-success-rate-by-project-response.dto';
+import { GetSuccessRateByProjectResponseDto } from './dto/get-success-rate-by-project-response.dto';
 import { GetSuccessRateByProjectDto } from './dto/get-success-rate-by-project.dto';
+import { GetAvgElapsedTimeResponseDto } from './dto/get-avg-elapsed-time-response.dto';
+import { GetTrafficRankResponseDto } from './dto/get-traffic-rank-response.dto';
+import { GetTrafficByGenerationResponseDto } from './dto/get-traffic-by-generation-response.dto';
 
 @Injectable()
 export class LogService {
@@ -24,26 +33,16 @@ export class LogService {
         private readonly logRepository: LogRepository,
     ) {}
 
-    async httpLog() {
-        const result = await this.logRepository.findHttpLog();
-
-        console.log(result);
-
-        return result;
-    }
-
-    async elapsedTime() {
+    async getAvgElapsedTime() {
         const result = await this.logRepository.findAvgElapsedTime();
 
-        console.log(result);
-
-        return result;
+        return plainToInstance(GetAvgElapsedTimeResponseDto, result);
     }
 
-    async trafficRank() {
-        const result = await this.logRepository.findCountByHost();
+    async getTrafficRank() {
+        const result = await this.logRepository.findTop5CountByHost();
 
-        return result.slice(0, 5);
+        return plainToInstance(GetTrafficRankResponseDto, result);
     }
 
     async getResponseSuccessRate(_getSuccessRateDto: GetSuccessRateDto) {
@@ -64,7 +63,7 @@ export class LogService {
 
         const result = await this.logRepository.findResponseSuccessRateByProject(project.domain);
 
-        return plainToInstance(GetSuccessRateByProjectResponseDTO, {
+        return plainToInstance(GetSuccessRateByProjectResponseDto, {
             projectName,
             ...result,
         });
@@ -73,21 +72,38 @@ export class LogService {
     async getTrafficByGeneration(_getTrafficByGenerationDto: GetTrafficByGenerationDto) {
         const result = await this.logRepository.findTrafficByGeneration();
 
-        return plainToInstance(GetTrafficByGenerationDto, result[0]);
+        return plainToInstance(GetTrafficByGenerationResponseDto, result);
     }
 
     async getPathSpeedRankByProject(getPathSpeedRankDto: GetPathSpeedRankDto) {
         const { projectName } = getPathSpeedRankDto;
-
         const project = await this.projectRepository.findOne({
             where: { name: projectName },
             select: ['domain'],
         });
+
         if (!project) throw new NotFoundException(`Project with name ${projectName} not found`);
 
-        const result = await this.logRepository.getPathSpeedRankByProject(project.domain);
+        console.log('??');
 
-        return plainToInstance(GetPathSpeedRankResponseDto, { projectName, ...result });
+        const fastestPaths = await this.logRepository.getFastestPathsByDomain(project.domain);
+        const slowestPaths = await this.logRepository.getSlowestPathsByDomain(project.domain);
+
+        return plainToInstance(GetPathSpeedRankResponseDto, {
+            projectName,
+            fastestPaths: fastestPaths.map((fastestPath) =>
+                plainToInstance(ResponseTimeByPath, {
+                    path: fastestPath.path,
+                    avgResponseTime: fastestPath.avg_elapsed_time,
+                }),
+            ),
+            slowestPaths: slowestPaths.map((slowestPath) =>
+                plainToInstance(ResponseTimeByPath, {
+                    path: slowestPath.path,
+                    avgResponseTime: slowestPath.avg_elapsed_time,
+                }),
+            ),
+        });
     }
 
     async getTrafficByProject(getTrafficByProjectDto: GetTrafficByProjectDto) {
@@ -99,12 +115,12 @@ export class LogService {
         });
         if (!project) throw new NotFoundException(`Project with name ${projectName} not found`);
 
-        const trafficData = await this.logRepository.getTrafficByProject(project.domain, timeUnit);
+        const results = await this.logRepository.getTrafficByProject(project.domain, timeUnit);
 
         return plainToInstance(GetTrafficByProjectResponseDto, {
             projectName,
             timeUnit,
-            trafficData,
+            trafficData: results.map((result) => plainToInstance(TrafficCountByTimeunit, result)),
         });
     }
 

--- a/backend/console-server/src/log/metric/avg-elapsed-time.metric.ts
+++ b/backend/console-server/src/log/metric/avg-elapsed-time.metric.ts
@@ -1,0 +1,8 @@
+import { IsNumber } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class AvgElapsedTimeMetric {
+    @Type(() => Number)
+    @IsNumber()
+    avg_elapsed_time: number;
+}

--- a/backend/console-server/src/log/metric/elapsed-time-by-path.metric.ts
+++ b/backend/console-server/src/log/metric/elapsed-time-by-path.metric.ts
@@ -1,0 +1,9 @@
+import { IsString } from 'class-validator';
+
+export class ElapsedTimeByPathMetric {
+    @IsString()
+    avg_elapsed_time: string;
+
+    @IsString()
+    path: string;
+}

--- a/backend/console-server/src/log/metric/error-rate.metric.ts
+++ b/backend/console-server/src/log/metric/error-rate.metric.ts
@@ -1,0 +1,8 @@
+import { Type } from 'class-transformer';
+import { IsNumber } from 'class-validator';
+
+export class ErrorRateMetric {
+    @Type(() => Number)
+    @IsNumber()
+    is_error_rate: number;
+}

--- a/backend/console-server/src/log/metric/success-rate.metric.ts
+++ b/backend/console-server/src/log/metric/success-rate.metric.ts
@@ -1,0 +1,8 @@
+import { Type } from 'class-transformer';
+import { IsNumber } from 'class-validator';
+
+export class SuccessRateMetric {
+    @Type(() => Number)
+    @IsNumber()
+    success_rate: number;
+}

--- a/backend/console-server/src/log/metric/traffic-count-by-timeunit.metric.ts
+++ b/backend/console-server/src/log/metric/traffic-count-by-timeunit.metric.ts
@@ -1,0 +1,11 @@
+import { Type } from 'class-transformer';
+import { IsNumber, IsString } from 'class-validator';
+
+export class TrafficCountByTimeunitMetric {
+    @Type(() => Number)
+    @IsNumber()
+    count: number;
+
+    @IsString()
+    timestamp: string;
+}

--- a/backend/console-server/src/log/metric/traffic-count.metric.ts
+++ b/backend/console-server/src/log/metric/traffic-count.metric.ts
@@ -1,0 +1,8 @@
+import { IsNumber } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class TrafficCountMetric {
+    @Type(() => Number)
+    @IsNumber()
+    count: number;
+}

--- a/backend/console-server/src/log/metric/traffic-rank-top5.metric.ts
+++ b/backend/console-server/src/log/metric/traffic-rank-top5.metric.ts
@@ -1,0 +1,5 @@
+import { TrafficRankMetric } from './traffic-rank.metric';
+
+export class TrafficRankTop5Metric {
+    rank: TrafficRankMetric[];
+}

--- a/backend/console-server/src/log/metric/traffic-rank.metric.ts
+++ b/backend/console-server/src/log/metric/traffic-rank.metric.ts
@@ -1,0 +1,11 @@
+import { IsNumber, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class TrafficRankMetric {
+    @IsString()
+    host: string;
+
+    @Type(() => Number)
+    @IsNumber()
+    count: number;
+}

--- a/backend/console-server/src/project/dto/find-by-generation-response.dto.ts
+++ b/backend/console-server/src/project/dto/find-by-generation-response.dto.ts
@@ -8,5 +8,5 @@ export class FindByGenerationResponseDto {
     })
     @IsNotEmpty()
     @Expose()
-    name: string;
+    value: string;
 }

--- a/backend/console-server/src/project/project.controller.ts
+++ b/backend/console-server/src/project/project.controller.ts
@@ -7,6 +7,8 @@ import { FindByGenerationDto } from './dto/find-by-generation.dto';
 import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { ProjectResponseDto } from './dto/create-project-response.dto';
 import { CountProjectByGenerationDto } from './dto/count-project-by-generation.dto';
+import { FindByGenerationResponseDto } from './dto/find-by-generation-response.dto';
+import { CountProjectByGenerationResponseDto } from './dto/count-project-by-generation-response.dto';
 
 @Controller('project')
 export class ProjectController {
@@ -35,7 +37,7 @@ export class ProjectController {
     @ApiResponse({
         status: 200,
         description: '프로젝트 목록이 성공적으로 반환됨',
-        type: ProjectResponseDto,
+        type: FindByGenerationResponseDto,
     })
     findByGeneration(@Query() findGenerationProjectDto: FindByGenerationDto) {
         return this.projectService.findByGeneration(findGenerationProjectDto);
@@ -50,7 +52,7 @@ export class ProjectController {
     @ApiResponse({
         status: 200,
         description: '기수의 전체 프로젝트 개수가 정상적으로 반환됨',
-        type: ProjectResponseDto,
+        type: CountProjectByGenerationResponseDto,
     })
     async countProjectByGeneration(
         @Query() countProjectByGenerationDto: CountProjectByGenerationDto,

--- a/backend/console-server/src/project/project.service.ts
+++ b/backend/console-server/src/project/project.service.ts
@@ -26,11 +26,11 @@ export class ProjectService {
             const project = this.projectRepository.create(createProjectDto);
             const result = await this.projectRepository.save(project);
 
-            new Promise((resolve, _reject) =>
-                this.mailService
-                    .sendNameServerInfo(createProjectDto.email, createProjectDto.name)
-                    .then(() => resolve),
-            );
+            // new Promise((resolve, _reject) =>
+            //     this.mailService
+            //         .sendNameServerInfo(createProjectDto.email, createProjectDto.name)
+            //         .then(() => resolve),
+            // ); // TODO: 주석 삭제 필요!!!!!!!!!
             return plainToInstance(ProjectResponseDto, result);
         } catch (error) {
             if (isUniqueConstraintViolation(error))
@@ -49,7 +49,7 @@ export class ProjectService {
             where: { generation: generation },
         });
 
-        return projects.map((p) => plainToInstance(FindByGenerationResponseDto, p.name));
+        return projects.map((p) => plainToInstance(FindByGenerationResponseDto, { value: p.name }));
     }
 
     async countProjectByGeneration(countProjectByGenerationDto: CountProjectByGenerationDto) {


### PR DESCRIPTION

### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
#

### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
- 매핑 방식 개선
  - repository에서 service로 데이터를 넘겨주기 전 metric 객체로 변환
  - metric 객체는 service 레이어에서 response dto로 변환해서 controller로 반환하는 방식

```typescript
// metric 객체
// traffic-count.metric.ts
import { IsNumber } from 'class-validator';
import { Type } from 'class-transformer';

export class TrafficCountMetric {
    @Type(() => Number)
    @IsNumber()
    count: number;
}

```
```typescript
async getTrafficByProject(domain: string, timeUnit: string) {
    const { query, params } = new TimeSeriesQueryBuilder()
        .metrics([
            { name: '*', aggregation: 'count' },
            { name: `toStartOf${timeUnit}(timestamp) as timestamp` },
        ])
        .from('http_log')
        .filter({ host: domain })
        .groupBy(['timestamp'])
        .orderBy(['timestamp'], false)
        .build();

    // query 메서드에서 제네릭 타입으로 해당 값을 명시해줘야함 (리턴 타입 정의)
    const results = await this.clickhouse.query<TrafficCountMetric>(query, params);

    // 쿼리 결과 반환하기 전 해당 객체로 매핑
    return results.map((result) => plainToInstance(TrafficCountMetric, result));
}
```

- 동작하지 않던 api 수정
  - 개별 트프로젝트의 경로별 응답 속도 순위: 1개씩 반환하던 문제 수정(원래는 3개씩 반환해야함)

- swagger 문서화 제대로 반영되지 않았던 부분 수정


### 🌀 PR Point
- 일반적인 ORM에서는 repository -> service 레이어간 데이터 이동할 때 service 레이어의 entity로 매핑함
  - 이 부분에서 사실 Dto로 래핑해주는 것이 좋은 방법이기도 함(레이어간 이동이기 때문에)
  - but, 투 머치이기도 하고 ORM의 경우 외부 의존성이기 때문에 굳이 Dto로 매핑하지는 않음
- 우리는 entity로 매핑하기에는 부적절하기 때문에 metric이라는 전송객체로 넘겨주는 방식을 선택했음


### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->


### 📷 스크린샷 또는 GIF
