### PR TITLE
[BE] log 도메인의 API 엔드포인트에 누락된 prefix 추가

### DIFF
--- a/backend/console-server/src/log/analytics/analytics.controller.ts
+++ b/backend/console-server/src/log/analytics/analytics.controller.ts
@@ -4,7 +4,7 @@ import { GetProjectDauResponseDto } from './dto/get-project-dau-response.dto';
 import { GetProjectDAU } from './dto/get-project-dau.dto';
 import { AnalyticsService } from './analytics.service';
 
-@Controller('analytics')
+@Controller('log/analytics')
 export class AnalyticsController {
     constructor(private readonly analyticService: AnalyticsService) {}
 

--- a/backend/console-server/src/log/elapsed-time/elapsed-time.controller.ts
+++ b/backend/console-server/src/log/elapsed-time/elapsed-time.controller.ts
@@ -9,7 +9,7 @@ import { GetPathElapsedTimeResponseDto } from './dto/get-path-elapsed-time-respo
 import { GetPathElapsedTimeRank } from './dto/get-path-elapsed-time.rank';
 import { CacheInterceptor } from '@nestjs/cache-manager';
 
-@Controller('elapsed-time')
+@Controller('log/elapsed-time')
 @UseInterceptors(CacheInterceptor)
 export class ElapsedTimeController {
     constructor(private readonly elapsedTimeService: ElapsedTimeService) {}

--- a/backend/console-server/src/log/log.controller.ts
+++ b/backend/console-server/src/log/log.controller.ts
@@ -1,4 +1,0 @@
-import { Controller } from '@nestjs/common';
-
-@Controller('log')
-export class LogController {}

--- a/backend/console-server/src/log/success-rate/success-rate.controller.ts
+++ b/backend/console-server/src/log/success-rate/success-rate.controller.ts
@@ -7,7 +7,7 @@ import { GetProjectSuccessRateResponseDto } from './dto/get-project-success-rate
 import { GetProjectSuccessRateDto } from './dto/get-project-success-rate.dto';
 import { CacheInterceptor } from '@nestjs/cache-manager';
 
-@Controller('success-rate')
+@Controller('log/success-rate')
 @UseInterceptors(CacheInterceptor)
 export class SuccessRateController {
     constructor(private readonly successRateService: SuccessRateService) {}

--- a/backend/console-server/src/log/traffic/traffic.controller.ts
+++ b/backend/console-server/src/log/traffic/traffic.controller.ts
@@ -12,7 +12,7 @@ import { GetTrafficTop5ChartResponseDto } from './dto/get-traffic-top5-chart-res
 import { GetTrafficTop5ChartDto } from './dto/get-traffic-top5-chart.dto';
 import { TrafficService } from './traffic.service';
 
-@Controller('traffic')
+@Controller('log/traffic')
 export class TrafficController {
     constructor(private readonly trafficService: TrafficService) {}
 


### PR DESCRIPTION
### 👀 관련 이슈
#152

### ✨ 작업한 내용
리팩터링 도중 log 도메인의 API 엔드포인트에서 `/log` prefix가 누락된 부분 추가
- 각 컨트롤러에 직접 prefix를 추가하는 방식으로 구현


### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->


### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->


### 📷 스크린샷 또는 GIF
