### PR TITLE
[BE] "NS"타입 DNS Query에 응답 & 작은 리팩토링 (createFlag)

### DIFF
--- a/backend/name-server/Dockerfile
+++ b/backend/name-server/Dockerfile
@@ -16,6 +16,8 @@ FROM node:22-alpine
 
 WORKDIR /usr/src/app
 
+RUN apk add --no-cache tzdata
+
 # 프로덕션 의존성 설치
 COPY package*.json ./
 RUN npm install --production

--- a/backend/name-server/docker-compose.yml
+++ b/backend/name-server/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     image: ghcr.io/boostcampwm-2024/web35-watchducks/backend/name-server:latest
     container_name: app-server-blue-1
     environment:
+      - TZ=Asia/Seoul
       - NODE_ENV=production
       - NAME_SERVER_PORT=3001
     restart: always
@@ -29,6 +30,7 @@ services:
     image: ghcr.io/boostcampwm-2024/web35-watchducks/backend/name-server:latest
     container_name: app-server-green-1
     environment:
+      - TZ=Asia/Seoul
       - NODE_ENV=production
       - NAME_SERVER_PORT=3002
     restart: always

--- a/backend/name-server/src/common/utils/validator/configuration.validator.ts
+++ b/backend/name-server/src/common/utils/validator/configuration.validator.ts
@@ -1,21 +1,35 @@
 import { ConfigurationError } from '../../error/configuration.error';
+import * as process from 'node:process';
 
 export interface ServerConfig {
     proxyServerIp: string;
     nameServerPort: number;
+    ttl: number;
+    nameServerDomainFirst: string;
+    nameServerDomainSecond: string;
 }
 
 export class ConfigurationValidator {
     static validate(): ServerConfig {
         const { PROXY_SERVER_IP, NAME_SERVER_PORT } = process.env;
+        const { TTL, NS_DOMAIN_FIRST, NS_DOMAIN_SECOND } = process.env;
 
-        if (!PROXY_SERVER_IP || !NAME_SERVER_PORT) {
+        if (
+            !PROXY_SERVER_IP ||
+            !NAME_SERVER_PORT ||
+            !TTL ||
+            !NS_DOMAIN_FIRST ||
+            !NS_DOMAIN_SECOND
+        ) {
             throw new ConfigurationError('Missing required environment variables');
         }
 
         return {
             proxyServerIp: PROXY_SERVER_IP,
             nameServerPort: parseInt(NAME_SERVER_PORT, 10),
+            ttl: parseInt(TTL, 10),
+            nameServerDomainFirst: NS_DOMAIN_FIRST,
+            nameServerDomainSecond: NS_DOMAIN_SECOND,
         };
     }
 }

--- a/backend/name-server/src/common/utils/validator/configuration.validator.ts
+++ b/backend/name-server/src/common/utils/validator/configuration.validator.ts
@@ -5,21 +5,21 @@ export interface ServerConfig {
     proxyServerIp: string;
     nameServerPort: number;
     ttl: number;
-    nameServerDomainFirst: string;
-    nameServerDomainSecond: string;
+    authoritativeNameServers: string[];
+    nameServerIp: string;
 }
 
 export class ConfigurationValidator {
     static validate(): ServerConfig {
         const { PROXY_SERVER_IP, NAME_SERVER_PORT } = process.env;
-        const { TTL, NS_DOMAIN_FIRST, NS_DOMAIN_SECOND } = process.env;
+        const { TTL, AUTHORITATIVE_NAME_SERVERS, NAME_SERVER_IP } = process.env;
 
         if (
             !PROXY_SERVER_IP ||
             !NAME_SERVER_PORT ||
             !TTL ||
-            !NS_DOMAIN_FIRST ||
-            !NS_DOMAIN_SECOND
+            !AUTHORITATIVE_NAME_SERVERS ||
+            !NAME_SERVER_IP
         ) {
             throw new ConfigurationError('Missing required environment variables');
         }
@@ -28,8 +28,8 @@ export class ConfigurationValidator {
             proxyServerIp: PROXY_SERVER_IP,
             nameServerPort: parseInt(NAME_SERVER_PORT, 10),
             ttl: parseInt(TTL, 10),
-            nameServerDomainFirst: NS_DOMAIN_FIRST,
-            nameServerDomainSecond: NS_DOMAIN_SECOND,
+            authoritativeNameServers: AUTHORITATIVE_NAME_SERVERS.split(',').map((s) => s.trim()),
+            nameServerIp: NAME_SERVER_IP,
         };
     }
 }

--- a/backend/name-server/src/database/query/dau-recorder.ts
+++ b/backend/name-server/src/database/query/dau-recorder.ts
@@ -8,8 +8,9 @@ export class DAURecorder implements DAURecorderInterface {
     private clickhouseClient = ClickhouseDatabase.getInstance();
 
     public async recordAccess(domain: string): Promise<void> {
-        const date = new Date().toISOString().slice(0, 10);
-        const values = [{ domain: domain.toLowerCase(), date, access: 1 }];
+        const dateString = new Date().toLocaleDateString('en-CA');
+        console.log(dateString);
+        const values = [{ domain: domain.toLowerCase(), date: dateString, access: 1 }];
         try {
             await this.clickhouseClient.insert({
                 table: 'dau',

--- a/backend/name-server/src/database/query/dau-recorder.ts
+++ b/backend/name-server/src/database/query/dau-recorder.ts
@@ -9,7 +9,6 @@ export class DAURecorder implements DAURecorderInterface {
 
     public async recordAccess(domain: string): Promise<void> {
         const dateString = new Date().toLocaleDateString('en-CA');
-        console.log(dateString);
         const values = [{ domain: domain.toLowerCase(), date: dateString, access: 1 }];
         try {
             await this.clickhouseClient.insert({

--- a/backend/name-server/src/server/constant/dns-packet.constant.ts
+++ b/backend/name-server/src/server/constant/dns-packet.constant.ts
@@ -20,7 +20,7 @@ export const RECORD_TYPE = {
 } as const;
 
 export const RECORD_CLASS = {
-    ITHERNET: 'IN',
+    INTERNET: 'IN',
 } as const;
 
 export const PACKET_TYPE = {

--- a/backend/name-server/src/server/constant/dns-packet.constant.ts
+++ b/backend/name-server/src/server/constant/dns-packet.constant.ts
@@ -13,4 +13,18 @@ export const RESPONSE_CODE = {
     SERVFAIL: 2, // 서버 에러
 } as const;
 
+export const RECORD_TYPE = {
+    ADDRESS: 'A',
+    IPV6_ADDRESS: 'AAAA',
+    NAME_SERVER: 'NS',
+} as const;
+
+export const RECORD_CLASS = {
+    ITHERNET: 'IN',
+} as const;
+
+export const PACKET_TYPE = {
+    RESPONSE: 'response',
+} as const;
+
 export type ResponseCodeType = (typeof RESPONSE_CODE)[keyof typeof RESPONSE_CODE];

--- a/backend/name-server/src/server/constant/dns-packet.constant.ts
+++ b/backend/name-server/src/server/constant/dns-packet.constant.ts
@@ -18,7 +18,6 @@ export const RESPONSE_CODE_MASK = 0x000f;
 
 export const RECORD_TYPE = {
     ADDRESS: 'A',
-    IPV6_ADDRESS: 'AAAA',
     NAME_SERVER: 'NS',
 } as const;
 

--- a/backend/name-server/src/server/constant/dns-packet.constant.ts
+++ b/backend/name-server/src/server/constant/dns-packet.constant.ts
@@ -1,4 +1,5 @@
 export const DNS_FLAGS = {
+    QUERY_RESPONSE: 0x8000, // Query/Response
     AUTHORITATIVE_ANSWER: 0x0400, // 권한 있는 응답 (네임서버가 해당 도메인의 공식 서버일 때)
     TRUNCATED_RESPONSE: 0x0200, // 응답이 잘린 경우 (UDP 크기 제한 초과)
     RECURSION_DESIRED: 0x0100, // 재귀적 쿼리 요청 (클라이언트가 설정)
@@ -12,6 +13,8 @@ export const RESPONSE_CODE = {
     NXDOMAIN: 3, // 도메인이 존재하지 않음
     SERVFAIL: 2, // 서버 에러
 } as const;
+
+export const RESPONSE_CODE_MASK = 0x000f;
 
 export const RECORD_TYPE = {
     ADDRESS: 'A',

--- a/backend/name-server/src/server/server.ts
+++ b/backend/name-server/src/server/server.ts
@@ -51,7 +51,10 @@ export class Server {
 
             const response = new DNSResponseBuilder(this.config, query)
                 .addAnswer(RESPONSE_CODE.NOERROR, question)
+                .addAuthorities(question)
+                .addAdditionals()
                 .build();
+
             const responseMsg = encode(response);
 
             await this.sendResponse(responseMsg, remoteInfo);

--- a/backend/name-server/src/server/server.ts
+++ b/backend/name-server/src/server/server.ts
@@ -2,15 +2,15 @@ import type { Socket } from 'dgram';
 import { createSocket, type RemoteInfo } from 'dgram';
 import { decode, encode } from 'dns-packet';
 import type { DecodedPacket, Question } from 'dns-packet';
-import type { ServerConfig } from 'common/utils/validator/configuration.validator';
+import type { ServerConfig } from '../common/utils/validator/configuration.validator';
 import { PacketValidator } from './utils/packet.validator';
 import { DNSResponseBuilder } from './utils/dns-response-builder';
 import { RESPONSE_CODE } from './constant/dns-packet.constant';
-import { logger } from 'common/utils/logger/console.logger';
+import { logger } from '../common/utils/logger/console.logger';
 import { ServerError } from './error/server.error';
 import type { ProjectQueryInterface } from 'database/query/project.query.interface';
 import type { DAURecorderInterface } from 'database/query/dau-recorder';
-import { MESSAGE_TYPE } from 'server/constant/message-type.constants';
+import { MESSAGE_TYPE } from '../server/constant/message-type.constants';
 
 export class Server {
     private server: Socket;

--- a/backend/name-server/src/server/utils/dns-response-builder.ts
+++ b/backend/name-server/src/server/utils/dns-response-builder.ts
@@ -57,7 +57,7 @@ export class DNSResponseBuilder {
             {
                 name: question.name,
                 type: RECORD_TYPE.ADDRESS,
-                class: RECORD_CLASS.ITHERNET,
+                class: RECORD_CLASS.INTERNET,
                 ttl: this.config.ttl,
                 data: this.config.proxyServerIp,
             },
@@ -68,13 +68,13 @@ export class DNSResponseBuilder {
     addAuthorities(question?: Question): this {
         if (!question) return this;
 
-        this.response.authorities = this.config.authoritativeNameServers.map((ns) => {
+        this.response.authorities = this.config.authoritativeNameServers.map((nameServerDomain) => {
             return {
                 name: question.name,
                 type: RECORD_TYPE.NAME_SERVER,
-                class: RECORD_CLASS.ITHERNET,
+                class: RECORD_CLASS.INTERNET,
                 ttl: this.config.ttl,
-                data: ns,
+                data: nameServerDomain,
             };
         });
         return this;
@@ -85,7 +85,7 @@ export class DNSResponseBuilder {
             return {
                 name: nameServerDomain,
                 type: RECORD_TYPE.ADDRESS,
-                class: RECORD_CLASS.ITHERNET,
+                class: RECORD_CLASS.INTERNET,
                 ttl: this.config.ttl,
                 data: this.config.nameServerIp,
             };

--- a/backend/name-server/src/server/utils/dns-response-builder.ts
+++ b/backend/name-server/src/server/utils/dns-response-builder.ts
@@ -81,9 +81,9 @@ export class DNSResponseBuilder {
     }
 
     addAdditionals(): this {
-        this.response.additionals = this.config.authoritativeNameServers.map((ns) => {
+        this.response.additionals = this.config.authoritativeNameServers.map((nameServerDomain) => {
             return {
-                name: ns,
+                name: nameServerDomain,
                 type: RECORD_TYPE.ADDRESS,
                 class: RECORD_CLASS.ITHERNET,
                 ttl: this.config.ttl,

--- a/backend/name-server/src/server/utils/dns-response-builder.ts
+++ b/backend/name-server/src/server/utils/dns-response-builder.ts
@@ -1,4 +1,4 @@
-import type { BaseAnswer, Packet, Question, RecordClass } from 'dns-packet';
+import type { BaseAnswer, Packet, Question } from 'dns-packet';
 import type { ServerConfig } from '../../common/utils/validator/configuration.validator';
 import { PacketValidator } from './packet.validator';
 import type { ResponseCodeType } from '../constant/dns-packet.constant';

--- a/backend/name-server/src/server/utils/dns-response-builder.ts
+++ b/backend/name-server/src/server/utils/dns-response-builder.ts
@@ -42,7 +42,7 @@ export class DNSResponseBuilder {
     }
 
     addAnswer(rcode: ResponseCodeType, question?: Question): this {
-        this.response.flags = 0x8000;
+        this.response.flags = DNS_FLAGS.QUERY_RESPONSE;
 
         if (this.response.flags && rcode === RESPONSE_CODE.NXDOMAIN) {
             this.response.flags |= RESPONSE_CODE.NXDOMAIN;

--- a/backend/name-server/src/server/utils/packet.validator.ts
+++ b/backend/name-server/src/server/utils/packet.validator.ts
@@ -1,9 +1,6 @@
 import type { Packet, Question } from 'dns-packet';
-import {
-    MESSAGE_TYPE,
-    MessageType,
-    MIN_DNS_MESSAGE_LENGTH,
-} from 'server/constant/message-type.constants';
+import type { MessageType } from '../../server/constant/message-type.constants';
+import { MESSAGE_TYPE, MIN_DNS_MESSAGE_LENGTH } from '../../server/constant/message-type.constants';
 
 type TypeGuardResult<T> = T extends Packet ? T & { questions: Question[] } : never;
 

--- a/backend/name-server/test/dns-response-builder.test.ts
+++ b/backend/name-server/test/dns-response-builder.test.ts
@@ -7,6 +7,9 @@ describe('DNSResponseBuilder의', () => {
     const mockConfig = {
         proxyServerIp: '127.0.0.1',
         nameServerPort: 5353,
+        ttl: 86400,
+        authoritativeNameServers: ['ns1.test-ns.com', 'ns2.test-ns.com'],
+        nameServerIp: '192.0.0.1',
     };
 
     const mockQuery: Packet = {

--- a/backend/name-server/test/dns-response-builder.test.ts
+++ b/backend/name-server/test/dns-response-builder.test.ts
@@ -25,16 +25,6 @@ describe('DNSResponseBuilder의', () => {
         ],
     };
 
-    test('build()는 권한 있는 응답 플래그를 추가하여 DNS 응답을 생성해야 합니다.', () => {
-        const builder = new DNSResponseBuilder(mockConfig, mockQuery);
-
-        const response = builder.build();
-
-        expect(response.id).toBe(mockQuery.id);
-        expect(response.type).toBe('response');
-        expect(response.flags).toBe(DNS_FLAGS.AUTHORITATIVE_ANSWER | DNS_FLAGS.RECURSION_DESIRED);
-    });
-
     test('addAnswer()는 올바른 정보를 담은 answer를 추가해야 합니다.', () => {
         const builder = new DNSResponseBuilder(mockConfig, mockQuery);
 
@@ -50,5 +40,18 @@ describe('DNSResponseBuilder의', () => {
             ttl: 86400,
             data: '127.0.0.1',
         });
+    });
+
+    test('build()는 정상적인 응답인 경우 권한있는 응답 플래그를 추가하여 DNS 응답을 생성해야 합니다.', () => {
+        const builder = new DNSResponseBuilder(mockConfig, mockQuery);
+
+        if (!PacketValidator.hasQuestions(mockQuery)) return;
+        const response = builder.addAnswer(RESPONSE_CODE.NOERROR, mockQuery.questions[0]).build();
+
+        expect(response.id).toBe(mockQuery.id);
+        expect(response.type).toBe('response');
+        expect(response.flags).toBe(
+            DNS_FLAGS.QUERY_RESPONSE | DNS_FLAGS.AUTHORITATIVE_ANSWER | DNS_FLAGS.RECURSION_DESIRED,
+        );
     });
 });

--- a/backend/name-server/test/server.test.ts
+++ b/backend/name-server/test/server.test.ts
@@ -1,7 +1,8 @@
 import * as dgram from 'dgram';
-import { encode, decode, Packet } from 'dns-packet';
+import type { Packet } from 'dns-packet';
+import { encode, decode } from 'dns-packet';
 import { Server } from '../src/server/server';
-import { ServerConfig } from '../src/common/utils/validator/configuration.validator';
+import type { ServerConfig } from '../src/common/utils/validator/configuration.validator';
 import { NORMAL_PACKET, NOT_EXIST_DOMAIN_PACKET } from './constant/packet';
 import { DAURecorder } from '../src/database/query/dau-recorder';
 import { TestProjectQuery } from './database/test-project.query';
@@ -13,10 +14,16 @@ describe('DNS 서버는 ', () => {
     const TEST_PORT = 53535;
     const TEST_HOST = '127.0.0.1';
     const TEST_PROXY_SERVER_IP = '127.1.1.1';
+    const TEST_TTL = 86400;
+    const TEST_AUTHORITATIVE_NAME_SERVERS = ['ns1.test-ns.com', 'ns2.test-ns.com'];
+    const TEST_NAME_SERVER_IP = '192.0.0.1';
 
     const config: ServerConfig = {
         proxyServerIp: TEST_PROXY_SERVER_IP,
         nameServerPort: TEST_PORT,
+        ttl: TEST_TTL,
+        authoritativeNameServers: TEST_AUTHORITATIVE_NAME_SERVERS,
+        nameServerIp: TEST_NAME_SERVER_IP,
     } as unknown as ServerConfig;
 
     beforeAll(async () => {


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
#160 

### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
- [x] NS 타입 DNS 쿼리도 만족하는 응답으로 변경
- [x] 혼재되어 있던 플래그 생성 로직을 createFlag()로 집중화
- [x] 매직넘버 제거, 상수 추가
- [x] 테스트 코드 살짝 수정
- [x] 도커파일&컴포즈 수정해 타임존 적용 + toISOString -> toLocaleDateString

### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
테스트 실행시 모듈 import문을 인식하지 못해 오류 나는 부분을 상대경로로 수정하였는데, 당장 해결이 필요한 문제일까요... 몇가지 시도는 해보았는데 jest config 등을 아예 새로 작성하며 테스트해봐야 할 것 같습니다 ㅠ

### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->
- 빌더 패턴을 사용한 기존 코드에서 벗어나지 않으면서, createFlag에 플래그 생성 역할을 집중시켜 분리하는 리팩토링을 진행하였습니다. 
- 기본 A 타입에 NS타입 쿼리에 모두 만족하는 응답을 제공합니다. 굳이 쿼리 타입에 따라 응답을 분기하지는 않았습니다. 
- 위 응답에 사용할 네임서버 정보를 포함하는 환경변수가 추가되었습니다. 노션 & 깃헙 시크릿에도 추가하였습니다.

### 📷 스크린샷 또는 GIF
- NS 타입 쿼리 옵션 주었을 때
  ![image](https://github.com/user-attachments/assets/a2e5fa6b-009c-45f2-8071-8a7a2527d399)
- 기본 (A 타입)
  ![image](https://github.com/user-attachments/assets/8abf234c-a9f6-45f4-9690-3d1872c55688)

- 테스트 결과
```
   PASS  test/server.test.ts
    DNS 서버는 
      ✓ 정상적인 도메인 네임 요청을 받으면 NOERROR 플래그를 응답해야합니다. (6 ms)
      ✓ 비정상적인 도메인 네임(없는 도메인 네임) 요청을 받으면 NXDOMAIN 플래그를 응답해야합니다. (12 ms)
      ✓ 정상적인 DNS 응답 구조로 응답해야합니다. (2 ms)
   PASS  test/dns-response-builder.test.ts
    DNSResponseBuilder의
      ✓ addAnswer()는 올바른 정보를 담은 answer를 추가해야 합니다. (2 ms)
      ✓ build()는 정상적인 응답인 경우 권한있는 응답 플래그를 추가하여 DNS 응답을 생성해야 합니다.
   PASS  test/packet.validator.test.ts
    PacketValidator의
      validatePacket()는
        ✓ 유효한 패킷에 true를 반환합니다. (2 ms)
        ✓ 유효하지 않은 패킷에 false를 반환합니다.
      hasQuestions()는
        ✓ 패킷에 question이 있다면 true를 반환합니다.
        ✓ 패킷에 question이 없다면 false를 반환합니다.
```

