### PR TITLE
[BE] 기수내 응답 성공률 랭킹 API 구현

### DIFF
--- a/backend/console-server/src/log/log.module.ts
+++ b/backend/console-server/src/log/log.module.ts
@@ -6,6 +6,7 @@ import { ElapsedTimeModule } from './elapsed-time/elapsed-time.module';
 import { TrafficModule } from './traffic/traffic.module';
 import { SuccessRateModule } from './success-rate/success-rate.module';
 import { AnalyticsModule } from './analytics/analytics.module';
+import { RankModule } from './rank/rank.module';
 
 @Module({
     imports: [
@@ -15,6 +16,7 @@ import { AnalyticsModule } from './analytics/analytics.module';
         TrafficModule,
         SuccessRateModule,
         AnalyticsModule,
+        RankModule,
     ],
 })
 export class LogModule {}

--- a/backend/console-server/src/log/rank/dto/get-success-rate-rank-response.dto.ts
+++ b/backend/console-server/src/log/rank/dto/get-success-rate-rank-response.dto.ts
@@ -21,7 +21,20 @@ export class GetSuccessRateRankResponseDto {
 
     @ApiProperty({
         description: '응답 성공률 순위',
-        example: 'watchducks',
+        example: [
+            {
+                projectName: 'test059',
+                successRate: 98.23100936524453,
+            },
+            {
+                projectName: 'test007',
+                successRate: 98.1094527363184,
+            },
+            {
+                projectName: 'test079',
+                successRate: 98.0083857442348,
+            },
+        ],
     })
     @Expose()
     rank: SuccessRateRank[];

--- a/backend/console-server/src/log/rank/dto/get-success-rate-rank-response.dto.ts
+++ b/backend/console-server/src/log/rank/dto/get-success-rate-rank-response.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose, Type } from 'class-transformer';
+import { IsNumber, IsString } from 'class-validator';
+
+export class SuccessRateRank {
+    @IsString()
+    projectName: string;
+
+    @Type(() => Number)
+    @IsNumber()
+    successRate: number;
+}
+
+export class GetSuccessRateRankResponseDto {
+    @ApiProperty({
+        description: '총 갯수',
+        example: 30,
+    })
+    @IsNumber()
+    total: number;
+
+    @ApiProperty({
+        description: '응답 성공률 순위',
+        example: 'watchducks',
+    })
+    @Expose()
+    rank: SuccessRateRank[];
+}

--- a/backend/console-server/src/log/rank/dto/get-success-rate-rank.dto.ts
+++ b/backend/console-server/src/log/rank/dto/get-success-rate-rank.dto.ts
@@ -1,0 +1,10 @@
+import { Type } from 'class-transformer';
+import { IsNumber } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetSuccessRateRankDto {
+    @ApiProperty({ description: '기수', example: 9 })
+    @Type(() => Number)
+    @IsNumber()
+    generation: number;
+}

--- a/backend/console-server/src/log/rank/metric/host-error-rate.metric.ts
+++ b/backend/console-server/src/log/rank/metric/host-error-rate.metric.ts
@@ -1,0 +1,13 @@
+import { Expose, Type } from 'class-transformer';
+import { IsNumber, IsString } from 'class-validator';
+
+export class HostErrorRateMetric {
+    @IsString()
+    @Expose()
+    host: string;
+
+    @Type(() => Number)
+    @IsNumber()
+    @Expose()
+    is_error_rate: number;
+}

--- a/backend/console-server/src/log/rank/rank.controller.spec.ts
+++ b/backend/console-server/src/log/rank/rank.controller.spec.ts
@@ -1,0 +1,78 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RankController } from './rank.controller';
+import { RankService } from './rank.service';
+import { GetSuccessRateRankDto } from './dto/get-success-rate-rank.dto';
+import { HttpStatus } from '@nestjs/common';
+
+describe('RankController', () => {
+    let controller: RankController;
+    let service: RankService;
+
+    const mockRankService = {
+        getSuccessRateRank: jest.fn(),
+    };
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            controllers: [RankController],
+            providers: [
+                {
+                    provide: RankService,
+                    useValue: mockRankService,
+                },
+            ],
+        }).compile();
+
+        controller = module.get<RankController>(RankController);
+        service = module.get<RankService>(RankService);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('RankController의', () => {
+        const mockDto: GetSuccessRateRankDto = {
+            generation: 1,
+        };
+
+        const mockResponse = {
+            rankings: [
+                {
+                    rank: 1,
+                    teamName: 'Team A',
+                    successRate: 98.5,
+                },
+                {
+                    rank: 2,
+                    teamName: 'Team B',
+                    successRate: 97.2,
+                },
+            ],
+        };
+
+        describe('getSuccessRateRank()는', () => {
+            it('정의되어 있어야 한다', () => {
+                expect(controller).toBeDefined();
+            });
+
+            it('성공률 랭킹 데이터를 반환해야 한다', async () => {
+                mockRankService.getSuccessRateRank.mockResolvedValue(mockResponse);
+
+                const result = await controller.getSuccessRateRank(mockDto);
+
+                expect(result).toBe(mockResponse);
+                expect(service.getSuccessRateRank).toHaveBeenCalledWith(mockDto);
+                expect(service.getSuccessRateRank).toHaveBeenCalledTimes(1);
+            });
+
+            it('서비스 계층에서 오류가 발생하면 해당 오류를 그대로 던져야 한다', async () => {
+                const error = new Error('Service error');
+                mockRankService.getSuccessRateRank.mockRejectedValue(error);
+
+                await expect(controller.getSuccessRateRank(mockDto)).rejects.toThrow(error);
+                expect(service.getSuccessRateRank).toHaveBeenCalledWith(mockDto);
+            });
+        });
+    });
+});

--- a/backend/console-server/src/log/rank/rank.controller.ts
+++ b/backend/console-server/src/log/rank/rank.controller.ts
@@ -1,0 +1,25 @@
+import { RankService } from './rank.service';
+import { Controller, Get, HttpCode, HttpStatus, Query } from '@nestjs/common';
+import { GetSuccessRateRankResponseDto } from './dto/get-success-rate-rank-response.dto';
+import { GetSuccessRateRankDto } from './dto/get-success-rate-rank.dto';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+@Controller('log/rank')
+export class RankController {
+    constructor(private readonly rankService: RankService) {}
+
+    @Get('/success-rate')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: '기수 내 응답 성공률 랭킹',
+        description: '요청받은 기수의 기수 내 응답 성공률 랭킹을 반환합니다.',
+    })
+    @ApiResponse({
+        status: HttpStatus.OK,
+        description: '기수 내 응답 성공률 랭킹이 성공적으로 반환됨.',
+        type: GetSuccessRateRankResponseDto,
+    })
+    async getSuccessRateRank(@Query() getSuccessRateRankDto: GetSuccessRateRankDto) {
+        return await this.rankService.getSuccessRateRank(getSuccessRateRankDto);
+    }
+}

--- a/backend/console-server/src/log/rank/rank.module.ts
+++ b/backend/console-server/src/log/rank/rank.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { ClickhouseModule } from '../../clickhouse/clickhouse.module';
+import { RankService } from './rank.service';
+import { RankRepository } from './rank.repository';
+import { Clickhouse } from '../../clickhouse/clickhouse';
+import { RankController } from './rank.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Project } from '../../project/entities/project.entity';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([Project]), ClickhouseModule],
+    controllers: [RankController],
+    providers: [RankService, RankRepository, Clickhouse],
+})
+export class RankModule {}

--- a/backend/console-server/src/log/rank/rank.repository.spec.ts
+++ b/backend/console-server/src/log/rank/rank.repository.spec.ts
@@ -1,0 +1,99 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { RankRepository } from './rank.repository';
+import { Clickhouse } from '../../clickhouse/clickhouse';
+import { TimeSeriesQueryBuilder } from '../../clickhouse/query-builder/time-series.query-builder';
+import { HostErrorRateMetric } from './metric/host-error-rate.metric';
+
+jest.mock('../../clickhouse/query-builder/time-series.query-builder');
+
+describe('RankRepository', () => {
+    let repository: RankRepository;
+    let clickhouse: Clickhouse;
+
+    const mockClickhouse = {
+        query: jest.fn(),
+    };
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                RankRepository,
+                {
+                    provide: Clickhouse,
+                    useValue: mockClickhouse,
+                },
+            ],
+        }).compile();
+
+        repository = module.get<RankRepository>(RankRepository);
+        clickhouse = module.get<Clickhouse>(Clickhouse);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('RankRepository의', () => {
+        describe('findSuccessRateOrderByCount()는', () => {
+            const mockQueryResult = {
+                query: 'SELECT host, is_error FROM http_log GROUP BY host ORDER BY is_error_rate',
+                params: {},
+            };
+
+            const mockResults = [
+                { host: 'test1.com', is_error_rate: 10 },
+                { host: 'test2.com', is_error_rate: 20 },
+            ];
+
+            beforeEach(() => {
+                (TimeSeriesQueryBuilder as jest.Mock).mockImplementation(() => ({
+                    metrics: jest.fn().mockReturnThis(),
+                    from: jest.fn().mockReturnThis(),
+                    groupBy: jest.fn().mockReturnThis(),
+                    orderBy: jest.fn().mockReturnThis(),
+                    build: jest.fn().mockReturnValue(mockQueryResult),
+                }));
+            });
+
+            it('TimeSeriesQueryBuilder를 사용하여 쿼리를 생성해야 한다', async () => {
+                mockClickhouse.query.mockResolvedValue(mockResults);
+
+                await repository.findSuccessRateOrderByCount();
+
+                expect(TimeSeriesQueryBuilder).toHaveBeenCalled();
+            });
+
+            it('생성된 쿼리로 Clickhouse를 호출해야 한다', async () => {
+                mockClickhouse.query.mockResolvedValue(mockResults);
+
+                await repository.findSuccessRateOrderByCount();
+
+                expect(clickhouse.query).toHaveBeenCalledWith(
+                    mockQueryResult.query,
+                    mockQueryResult.params,
+                );
+            });
+
+            it('조회 결과를 HostErrorRateMetric 인스턴스로 변환하여 반환해야 한다', async () => {
+                mockClickhouse.query.mockResolvedValue(mockResults);
+
+                const result = await repository.findSuccessRateOrderByCount();
+
+                expect(result).toHaveLength(mockResults.length);
+                result.forEach((item, index) => {
+                    expect(item).toBeInstanceOf(HostErrorRateMetric);
+                    expect(item.host).toBe(mockResults[index].host);
+                    expect(item.is_error_rate).toBe(mockResults[index].is_error_rate);
+                });
+            });
+
+            it('Clickhouse 쿼리 실패 시 에러를 전파해야 한다', async () => {
+                const error = new Error('Clickhouse query failed');
+                mockClickhouse.query.mockRejectedValue(error);
+
+                await expect(repository.findSuccessRateOrderByCount()).rejects.toThrow(error);
+            });
+        });
+    });
+});

--- a/backend/console-server/src/log/rank/rank.repository.ts
+++ b/backend/console-server/src/log/rank/rank.repository.ts
@@ -2,7 +2,6 @@ import { Clickhouse } from '../../clickhouse/clickhouse';
 import { Injectable } from '@nestjs/common';
 import { TimeSeriesQueryBuilder } from '../../clickhouse/query-builder/time-series.query-builder';
 import { HostErrorRateMetric } from './metric/host-error-rate.metric';
-import { plainToInstance } from 'class-transformer';
 
 @Injectable()
 export class RankRepository {
@@ -16,8 +15,6 @@ export class RankRepository {
             .orderBy(['is_error_rate'])
             .build();
 
-        const results = await this.clickhouse.query<HostErrorRateMetric>(query, params);
-
-        return results.map((result) => plainToInstance(HostErrorRateMetric, result));
+        return await this.clickhouse.query<HostErrorRateMetric>(query, params);
     }
 }

--- a/backend/console-server/src/log/rank/rank.repository.ts
+++ b/backend/console-server/src/log/rank/rank.repository.ts
@@ -1,0 +1,23 @@
+import { Clickhouse } from '../../clickhouse/clickhouse';
+import { Injectable } from '@nestjs/common';
+import { TimeSeriesQueryBuilder } from '../../clickhouse/query-builder/time-series.query-builder';
+import { HostErrorRateMetric } from './metric/host-error-rate.metric';
+import { plainToInstance } from 'class-transformer';
+
+@Injectable()
+export class RankRepository {
+    constructor(private readonly clickhouse: Clickhouse) {}
+
+    async findSuccessRateOrderByCount() {
+        const { query, params } = new TimeSeriesQueryBuilder()
+            .metrics([{ name: 'host' }, { name: 'is_error', aggregation: 'rate' }])
+            .from('http_log')
+            .groupBy(['host'])
+            .orderBy(['is_error_rate'])
+            .build();
+
+        const results = await this.clickhouse.query<HostErrorRateMetric>(query, params);
+
+        return results.map((result) => plainToInstance(HostErrorRateMetric, result));
+    }
+}

--- a/backend/console-server/src/log/rank/rank.service.spec.ts
+++ b/backend/console-server/src/log/rank/rank.service.spec.ts
@@ -1,0 +1,97 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { RankService } from './rank.service';
+import { RankRepository } from './rank.repository';
+import { Project } from '../../project/entities/project.entity';
+import type { Repository } from 'typeorm';
+import type { GetSuccessRateRankDto } from './dto/get-success-rate-rank.dto';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+describe('RankService', () => {
+    let service: RankService;
+    let rankRepository: RankRepository;
+    let projectRepository: Repository<Project>;
+
+    const mockRankRepository = {
+        findSuccessRateOrderByCount: jest.fn(),
+    };
+
+    const mockProjectRepository = {
+        find: jest.fn(),
+    };
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                RankService,
+                {
+                    provide: RankRepository,
+                    useValue: mockRankRepository,
+                },
+                {
+                    provide: getRepositoryToken(Project),
+                    useValue: mockProjectRepository,
+                },
+            ],
+        }).compile();
+
+        service = module.get<RankService>(RankService);
+        rankRepository = module.get<RankRepository>(RankRepository);
+        projectRepository = module.get<Repository<Project>>(getRepositoryToken(Project));
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('RankService의', () => {
+        describe('getSuccessRateRank()는', () => {
+            const mockDto: GetSuccessRateRankDto = {
+                generation: 1,
+            };
+
+            const mockRankResults = [
+                { host: 'test1.com', is_error_rate: 10 },
+                { host: 'test2.com', is_error_rate: 20 },
+            ];
+
+            const mockProjects = [
+                { domain: 'test1.com', name: 'Project 1' },
+                { domain: 'test2.com', name: 'Project 2' },
+            ];
+
+            it('성공률 순위를 정상적으로 계산하여 반환해야 한다', async () => {
+                mockRankRepository.findSuccessRateOrderByCount.mockResolvedValue(mockRankResults);
+                mockProjectRepository.find.mockResolvedValue(mockProjects);
+
+                const result = await service.getSuccessRateRank(mockDto);
+
+                expect(result.total).toBe(mockRankResults.length);
+                expect(result.rank).toHaveLength(mockRankResults.length);
+                expect(result.rank[0].projectName).toBe('Project 1');
+                expect(result.rank[0].successRate).toBe(90);
+                expect(result.rank[1].projectName).toBe('Project 2');
+                expect(result.rank[1].successRate).toBe(80);
+            });
+
+            it('프로젝트 정보가 없는 경우 Unknown으로 표시해야 한다', async () => {
+                mockRankRepository.findSuccessRateOrderByCount.mockResolvedValue(mockRankResults);
+                mockProjectRepository.find.mockResolvedValue([mockProjects[0]]);
+
+                const result = await service.getSuccessRateRank(mockDto);
+
+                expect(result.rank[1].projectName).toBe('Unknown');
+            });
+
+            it('rankRepository와 projectRepository를 호출해야 한다', async () => {
+                mockRankRepository.findSuccessRateOrderByCount.mockResolvedValue(mockRankResults);
+                mockProjectRepository.find.mockResolvedValue(mockProjects);
+
+                await service.getSuccessRateRank(mockDto);
+
+                expect(rankRepository.findSuccessRateOrderByCount).toHaveBeenCalled();
+                expect(projectRepository.find).toHaveBeenCalled();
+            });
+        });
+    });
+});

--- a/backend/console-server/src/log/rank/rank.service.ts
+++ b/backend/console-server/src/log/rank/rank.service.ts
@@ -1,0 +1,44 @@
+import { RankRepository } from './rank.repository';
+import { Injectable } from '@nestjs/common';
+import { GetSuccessRateRankDto } from './dto/get-success-rate-rank.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Project } from '../../project/entities/project.entity';
+import { In, Repository } from 'typeorm';
+import { plainToInstance } from 'class-transformer';
+import {
+    GetSuccessRateRankResponseDto,
+    SuccessRateRank,
+} from './dto/get-success-rate-rank-response.dto';
+
+@Injectable()
+export class RankService {
+    constructor(
+        @InjectRepository(Project)
+        private readonly projectRepository: Repository<Project>,
+        private readonly rankRepository: RankRepository,
+    ) {}
+
+    async getSuccessRateRank(_getSuccessRateRankDto: GetSuccessRateRankDto) {
+        const results = await this.rankRepository.findSuccessRateOrderByCount();
+        const hosts = results.map((result) => result.host);
+
+        const projects = await this.projectRepository.find({
+            select: ['domain', 'name'],
+            where: {
+                domain: In(hosts),
+            },
+        });
+        const projectMap = new Map(projects.map((project) => [project.domain, project]));
+
+        const rank = results.map((result) => {
+            const project = projectMap.get(result.host);
+
+            return plainToInstance(SuccessRateRank, {
+                projectName: project?.name || `Unknown`,
+                successRate: 100 - result.is_error_rate,
+            });
+        });
+
+        return plainToInstance(GetSuccessRateRankResponseDto, { total: results.length, rank });
+    }
+}

--- a/backend/console-server/src/log/traffic/traffic.repository.ts
+++ b/backend/console-server/src/log/traffic/traffic.repository.ts
@@ -106,7 +106,7 @@ export class TrafficRepository {
                        FROM (
                                 SELECT
                                     host,
-                                    toDateTime64(toStartOfInterval(timestamp, INTERVAL 1 MINUTE), 0) as timestamp,
+                                    toDateTime64(toStartOfInterval(timestamp, INTERVAL 10 MINUTE ), 0) as timestamp,
                                     count() as requests_count
                                 FROM http_log
                                 WHERE timestamp >= {startTime: DateTime64(3)}

--- a/backend/console-server/src/log/traffic/traffic.repository.ts
+++ b/backend/console-server/src/log/traffic/traffic.repository.ts
@@ -78,10 +78,13 @@ export class TrafficRepository {
 
         return results.map((result) => plainToInstance(TrafficCountMetric, result));
     }
+
     async findTrafficTop5Chart() {
         const now = new Date();
         const today = new Date(now.setHours(0, 0, 0, 0));
         const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
+
+        console.log(today, yesterday);
 
         const query = `WITH top_hosts AS (
             SELECT host


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
#170 

### ✨ 작업한 내용
#### 🚀  기수내 응답 성공률 랭킹 API 구현

구조
```shell
./src/log/rank
├── dto
│   ├── get-success-rate-rank-response.dto.ts
│   └── get-success-rate-rank.dto.ts
├── metric
│   └── host-error-rate.metric.ts
├── rank.controller.spec.ts
├── rank.controller.ts
├── rank.module.ts
├── rank.repository.spec.ts
├── rank.repository.ts
├── rank.service.spec.ts
└── rank.service.ts
```
요청 형식
`GET /api/log/rank/success-rate`

응답 형식
```json
{
  "total": 30,
  "rank": [
    {
      "projectName": "test059",
      "successRate": 98.23100936524453
    },
    {
      "projectName": "test007",
      "successRate": 98.1094527363184
    },
    {
      "projectName": "test079",
      "successRate": 98.0083857442348
    }
  ]
}
```

### 🌀 PR Point
프로젝트 명을 매핑할 때 데이터베이스를 한 번만 찌르도록 구현했습니다. 이 과정에서 배열의 index로 매핑하는 것보다는 map으로 구조화한 후 매핑하는 것이 더 안전할 것 같아서 해당 방식으로 구현했습니다. 혹시 더 좋은 방법이 있을까요?

### 📷 스크린샷 또는 GIF
![스크린샷 2024-11-25 오후 11 46 01](https://github.com/user-attachments/assets/9f9a34be-9b6a-43bd-a316-1c31b9c6f649)

