### PR TITLE
[BE] 개별 프로젝트 트래픽 API에 변경된 요구사항 반영해 수정

### DIFF
--- a/backend/console-server/Dockerfile
+++ b/backend/console-server/Dockerfile
@@ -16,6 +16,8 @@ FROM node:22-alpine
 
 WORKDIR /usr/src/app
 
+RUN apk add --no-cache tzdata
+
 # 프로덕션 의존성 설치
 COPY package*.json ./
 RUN npm install --production
@@ -23,10 +25,10 @@ RUN npm install --production
 # 빌드 결과물 복사
 COPY --from=build /usr/src/app/dist ./dist
 
-# PM2 설치 (옵션)
+# PM2 설치
 RUN npm install pm2 -g
 
-# PM2 설정 파일 복사 (옵션)
+# PM2 설정 파일 복사
 COPY ecosystem.config.js ./
 
 # 애플리케이션 실행

--- a/backend/console-server/docker-compose.yml
+++ b/backend/console-server/docker-compose.yml
@@ -28,6 +28,7 @@ services:
     image: ghcr.io/boostcampwm-2024/web35-watchducks/backend/console-server:latest
     container_name: app-server-blue-1
     environment:
+      - TZ=Asia/Seoul
       - NODE_ENV=production
       - PORT=3001
     restart: always
@@ -45,6 +46,7 @@ services:
     image: ghcr.io/boostcampwm-2024/web35-watchducks/backend/console-server:latest
     container_name: app-server-green-1
     environment:
+      - TZ=Asia/Seoul
       - NODE_ENV=production
       - PORT=3002
     restart: always

--- a/backend/console-server/src/log/traffic/dto/get-traffic-by-project-response.dto.ts
+++ b/backend/console-server/src/log/traffic/dto/get-traffic-by-project-response.dto.ts
@@ -3,7 +3,7 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class TrafficCountByTimeunit {
     @ApiProperty({
-        example: '2024-11-07 23:07:28',
+        example: '2024-11-07 23:00:00',
         description: '시간 단위 별 타임스탬프',
     })
     @Expose()
@@ -27,15 +27,15 @@ export class GetTrafficByProjectResponseDto {
     projectName: string;
 
     @ApiProperty({
-        example: 'hour',
-        description: '시간 단위',
+        example: '24hours',
+        description: '데이터 범위',
     })
     @Expose()
-    timeUnit: string;
+    timeRange: string;
 
     @ApiProperty({
         type: [TrafficCountByTimeunit],
-        description: '시간 단위 별 트래픽 데이터',
+        description: '시간 범위 별 트래픽 데이터',
     })
     @Expose()
     @Type(() => TrafficCountByTimeunit)

--- a/backend/console-server/src/log/traffic/dto/get-traffic-by-project-response.dto.ts
+++ b/backend/console-server/src/log/traffic/dto/get-traffic-by-project-response.dto.ts
@@ -27,7 +27,7 @@ export class GetTrafficByProjectResponseDto {
     projectName: string;
 
     @ApiProperty({
-        example: '24hours',
+        example: 'day',
         description: '데이터 범위',
     })
     @Expose()

--- a/backend/console-server/src/log/traffic/dto/get-traffic-by-project.dto.ts
+++ b/backend/console-server/src/log/traffic/dto/get-traffic-by-project.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsString, IsIn } from 'class-validator';
+import { IsNotEmpty, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { TIME_RANGE, TimeRange } from '../traffic.constant';
 

--- a/backend/console-server/src/log/traffic/dto/get-traffic-by-project.dto.ts
+++ b/backend/console-server/src/log/traffic/dto/get-traffic-by-project.dto.ts
@@ -12,8 +12,8 @@ export class GetTrafficByProjectDto {
     projectName: string;
 
     @ApiProperty({
-        example: '24hours',
-        description: '데이터 범위 (24hours, 1week, 1month)',
+        example: 'day',
+        description: '데이터 범위 (day, week, month)',
         enum: Object.values(TIME_RANGE),
     })
     @IsNotEmpty()

--- a/backend/console-server/src/log/traffic/dto/get-traffic-by-project.dto.ts
+++ b/backend/console-server/src/log/traffic/dto/get-traffic-by-project.dto.ts
@@ -1,6 +1,5 @@
 import { IsNotEmpty, IsString, IsIn } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
-import { Transform } from 'class-transformer';
 
 export class GetTrafficByProjectDto {
     @ApiProperty({
@@ -12,19 +11,12 @@ export class GetTrafficByProjectDto {
     projectName: string;
 
     @ApiProperty({
-        example: 'hour',
-        description: '시간 단위 (Minute, Hour, Day, Week, Month)',
-        enum: ['Minute', 'Hour', 'Day', 'Week', 'Month'],
+        example: '24hours',
+        description: '데이터 범위 (24hours, 1week, 1month)',
+        enum: ['24hours', '1week', '1month'],
     })
     @IsNotEmpty()
     @IsString()
-    @Transform(({ value }) => {
-        if (typeof value === 'string') {
-            const lower = value.toLowerCase();
-            return lower.charAt(0).toUpperCase() + lower.slice(1);
-        }
-        return value;
-    })
-    @IsIn(['Minute', 'Hour', 'Day', 'Week', 'Month'])
-    timeUnit: string;
+    @IsIn(['24hours', '1week', '1month'])
+    timeRange: string;
 }

--- a/backend/console-server/src/log/traffic/dto/get-traffic-by-project.dto.ts
+++ b/backend/console-server/src/log/traffic/dto/get-traffic-by-project.dto.ts
@@ -1,5 +1,6 @@
 import { IsNotEmpty, IsString, IsIn } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { TIME_RANGE, TimeRange } from '../traffic.constant';
 
 export class GetTrafficByProjectDto {
     @ApiProperty({
@@ -13,10 +14,8 @@ export class GetTrafficByProjectDto {
     @ApiProperty({
         example: '24hours',
         description: '데이터 범위 (24hours, 1week, 1month)',
-        enum: ['24hours', '1week', '1month'],
+        enum: Object.values(TIME_RANGE),
     })
     @IsNotEmpty()
-    @IsString()
-    @IsIn(['24hours', '1week', '1month'])
-    timeRange: string;
+    timeRange: TimeRange;
 }

--- a/backend/console-server/src/log/traffic/traffic.constant.ts
+++ b/backend/console-server/src/log/traffic/traffic.constant.ts
@@ -1,0 +1,20 @@
+export const TIME_RANGE = {
+    DAY: '24hours',
+    WEEK: '1week',
+    MONTH: '1month',
+} as const;
+
+export const TIME_UNIT = {
+    ONE_MINUTE: '1 minute',
+    TWENTY_MINUTES: '20 minute',
+    ONE_HOUR: '1 hour',
+};
+
+export const TIME_RANGE_UNIT_MAP = {
+    [TIME_RANGE.DAY]: TIME_UNIT.ONE_MINUTE,
+    [TIME_RANGE.WEEK]: TIME_UNIT.TWENTY_MINUTES,
+    [TIME_RANGE.MONTH]: TIME_UNIT.ONE_HOUR,
+} as const;
+
+export type TimeRange = keyof typeof TIME_RANGE_UNIT_MAP;
+export type TimeUnit = (typeof TIME_RANGE_UNIT_MAP)[TimeRange];

--- a/backend/console-server/src/log/traffic/traffic.constant.ts
+++ b/backend/console-server/src/log/traffic/traffic.constant.ts
@@ -4,16 +4,16 @@ export const TIME_RANGE = {
     MONTH: '1month',
 } as const;
 
-export const TIME_UNIT = {
-    ONE_MINUTE: '1 minute',
-    TWENTY_MINUTES: '20 minute',
-    ONE_HOUR: '1 hour',
+export const CLICKHOUSE_TIME_UNIT = {
+    ONE_MINUTE: 'Minute',
+    FIFTEEN_MINUTES: 'FifteenMinutes',
+    ONE_HOUR: 'Hour',
 };
 
 export const TIME_RANGE_UNIT_MAP = {
-    [TIME_RANGE.DAY]: TIME_UNIT.ONE_MINUTE,
-    [TIME_RANGE.WEEK]: TIME_UNIT.TWENTY_MINUTES,
-    [TIME_RANGE.MONTH]: TIME_UNIT.ONE_HOUR,
+    [TIME_RANGE.DAY]: CLICKHOUSE_TIME_UNIT.ONE_MINUTE,
+    [TIME_RANGE.WEEK]: CLICKHOUSE_TIME_UNIT.FIFTEEN_MINUTES,
+    [TIME_RANGE.MONTH]: CLICKHOUSE_TIME_UNIT.ONE_HOUR,
 } as const;
 
 export type TimeRange = keyof typeof TIME_RANGE_UNIT_MAP;

--- a/backend/console-server/src/log/traffic/traffic.constant.ts
+++ b/backend/console-server/src/log/traffic/traffic.constant.ts
@@ -1,7 +1,7 @@
 export const TIME_RANGE = {
-    DAY: '24hours',
-    WEEK: '1week',
-    MONTH: '1month',
+    DAY: 'day',
+    WEEK: 'week',
+    MONTH: 'month',
 } as const;
 
 export const CLICKHOUSE_TIME_UNIT = {

--- a/backend/console-server/src/log/traffic/traffic.controller.spec.ts
+++ b/backend/console-server/src/log/traffic/traffic.controller.spec.ts
@@ -80,10 +80,10 @@ describe('TrafficController 테스트', () => {
     });
 
     describe('getTrafficByProject()는', () => {
-        const mockRequestDto = { projectName: 'example-project', timeUnit: 'month' };
+        const mockRequestDto = { projectName: 'example-project', timeRange: '1month' as const };
         const mockResponseDto = {
             projectName: 'example-project',
-            timeUnit: 'month',
+            timeRange: '1month',
             trafficData: [
                 { timestamp: '2024-11-01', count: 14 },
                 { timestamp: '2024-10-01', count: 10 },
@@ -96,7 +96,7 @@ describe('TrafficController 테스트', () => {
 
             expect(result).toEqual(mockResponseDto);
             expect(result).toHaveProperty('projectName', mockRequestDto.projectName);
-            expect(result).toHaveProperty('timeUnit', mockRequestDto.timeUnit);
+            expect(result).toHaveProperty('timeRange', mockRequestDto.timeRange);
             expect(result.trafficData).toHaveLength(2);
             expect(result.trafficData[0]).toHaveProperty('timestamp', '2024-11-01');
             expect(result.trafficData[0]).toHaveProperty('count', 14);
@@ -117,7 +117,7 @@ describe('TrafficController 테스트', () => {
         it('빈 트래픽 데이터를 반환해야 한다 (No Data)', async () => {
             const emptyResponseDto = {
                 projectName: 'example-project',
-                timeUnit: 'month',
+                timeRange: '1month',
                 trafficData: [],
             };
             mockTrafficService.getTrafficByProject.mockResolvedValue(emptyResponseDto);
@@ -126,7 +126,7 @@ describe('TrafficController 테스트', () => {
 
             expect(result).toEqual(emptyResponseDto);
             expect(result).toHaveProperty('projectName', mockRequestDto.projectName);
-            expect(result).toHaveProperty('timeUnit', mockRequestDto.timeUnit);
+            expect(result).toHaveProperty('timeRange', mockRequestDto.timeRange);
             expect(result.trafficData).toHaveLength(0);
             expect(service.getTrafficByProject).toHaveBeenCalledWith(mockRequestDto);
             expect(service.getTrafficByProject).toHaveBeenCalledTimes(1);

--- a/backend/console-server/src/log/traffic/traffic.controller.spec.ts
+++ b/backend/console-server/src/log/traffic/traffic.controller.spec.ts
@@ -80,10 +80,10 @@ describe('TrafficController 테스트', () => {
     });
 
     describe('getTrafficByProject()는', () => {
-        const mockRequestDto = { projectName: 'example-project', timeRange: '1month' as const };
+        const mockRequestDto = { projectName: 'example-project', timeRange: 'month' as const };
         const mockResponseDto = {
             projectName: 'example-project',
-            timeRange: '1month',
+            timeRange: 'month',
             trafficData: [
                 { timestamp: '2024-11-01', count: 14 },
                 { timestamp: '2024-10-01', count: 10 },
@@ -117,7 +117,7 @@ describe('TrafficController 테스트', () => {
         it('빈 트래픽 데이터를 반환해야 한다 (No Data)', async () => {
             const emptyResponseDto = {
                 projectName: 'example-project',
-                timeRange: '1month',
+                timeRange: 'month',
                 trafficData: [],
             };
             mockTrafficService.getTrafficByProject.mockResolvedValue(emptyResponseDto);

--- a/backend/console-server/src/log/traffic/traffic.controller.ts
+++ b/backend/console-server/src/log/traffic/traffic.controller.ts
@@ -35,11 +35,11 @@ export class TrafficController {
     @HttpCode(HttpStatus.OK)
     @ApiOperation({
         summary: '프로젝트 별 트래픽 조회',
-        description: '프로젝트 이름과 시간 단위로 특정 프로젝트의 트래픽 데이터를 반환합니다.',
+        description: '특정 프로젝트의 지난 24시간/1주일/1개월 간의 트래픽 데이터를 반환합니다.',
     })
     @ApiResponse({
         status: HttpStatus.OK,
-        description: '특정 프로젝트의 트래픽 데이터가 반환됨.',
+        description: '요청한 프로젝트명/기간에 맞는 트래픽 데이터가 반환됨.',
         type: GetTrafficByProjectResponseDto,
     })
     async getTrafficByProject(@Query() getTrafficByProjectDto: GetTrafficByProjectDto) {

--- a/backend/console-server/src/log/traffic/traffic.repository.ts
+++ b/backend/console-server/src/log/traffic/traffic.repository.ts
@@ -76,9 +76,7 @@ export class TrafficRepository {
             .orderBy(['timestamp'], false)
             .build();
 
-        const results = await this.clickhouse.query<TrafficCountMetric>(query, params);
-
-        return results.map((result) => plainToInstance(TrafficCountMetric, result));
+        return await this.clickhouse.query<TrafficCountMetric>(query, params);
     }
 
     async findTrafficTop5Chart() {

--- a/backend/console-server/src/log/traffic/traffic.repository.ts
+++ b/backend/console-server/src/log/traffic/traffic.repository.ts
@@ -6,6 +6,7 @@ import { TrafficRankMetric } from './metric/traffic-rank.metric';
 import { TrafficRankTop5Metric } from './metric/traffic-rank-top5.metric';
 import { TrafficCountMetric } from './metric/traffic-count.metric';
 import { Injectable } from '@nestjs/common';
+import type { TimeUnit } from './traffic.constant';
 
 @Injectable()
 export class TrafficRepository {
@@ -62,13 +63,14 @@ export class TrafficRepository {
         return this.clickhouse.query<{ count: number }>(queryBuilder.query, queryBuilder.params);
     }
 
-    async findTrafficByProject(domain: string, timeUnit: string) {
+    async findTrafficByProject(domain: string, start: Date, end: Date, timeUnit: TimeUnit) {
         const { query, params } = new TimeSeriesQueryBuilder()
             .metrics([
                 { name: '*', aggregation: 'count' },
                 { name: `toStartOf${timeUnit}(timestamp) as timestamp` },
             ])
             .from('http_log')
+            .timeBetween(start, end)
             .filter({ host: domain })
             .groupBy(['timestamp'])
             .orderBy(['timestamp'], false)
@@ -78,6 +80,7 @@ export class TrafficRepository {
 
         return results.map((result) => plainToInstance(TrafficCountMetric, result));
     }
+
     async findTrafficTop5Chart() {
         const now = new Date();
         const today = new Date(now.setHours(0, 0, 0, 0));

--- a/backend/console-server/src/log/traffic/traffic.service.spec.ts
+++ b/backend/console-server/src/log/traffic/traffic.service.spec.ts
@@ -104,7 +104,7 @@ describe('TrafficService 테스트', () => {
     });
 
     describe('getTrafficByProject()는', () => {
-        const mockRequestDto = { projectName: 'example-project', timeRange: '1month' as const };
+        const mockRequestDto = { projectName: 'example-project', timeRange: 'month' as const };
         const mockProject = {
             name: 'example-project',
             domain: 'example.com',
@@ -115,7 +115,7 @@ describe('TrafficService 테스트', () => {
         ];
         const mockResponseDto = {
             projectName: 'example-project',
-            timeRange: '1month',
+            timeRange: 'month',
             trafficData: mockTrafficData,
         };
 


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
#108

### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
- [x] 수정된 요구사항에 맞게 DTO, controller, swagger  수정
- [x] TIME_RANGE, TIME_UNIT 대문자 상수와 필요한 타입 선언해서 사용
- [x] 서비스에 calculateDateTimeRange 유틸 private 함수 작성
- [x] timeBetween 사용해 레포지토리 조금 수정
- [x] 테스트 코드 수정
- [x] timeRange 입력값 수정 요구사항 반영
---
- [x] Dockerfile, docker-compose 타임존 수정


### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
- query 메소드가 타입 파라미터를 받고, 반환 타입 힌트도 넘겨준 타입으로 잘 나오길래 한번 map과 plainToInstance 지워보았습니다. metric 타입만 잘 넘겨주면 원하는 타입으로 잘 돌아오는 것 같습니다. 혹시 제가 놓친 게 있고, map과 plainToInstance 필요한 이유가 있다면 알려주세용 (아마 생성된 변수명이 snake_case라서 마음에 안들때는 계속 써도 되지 않을까 싶네요.. 너무 큰 데이터가 아니라면!)
  ![Screenshot 2024-11-26 at 2 03 01 AM](https://github.com/user-attachments/assets/e8ba4bbd-b502-4f30-81a5-b9a678bb1f2d)
- 이외에도 constant 파일 만들었는데 이것이 적절한지, 
- 서비스와 레포지토리 메소드 역할이 너무 크지는 않은지 등등 피드백 주시면 감사히 받겠습니다!!!

### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->
- 테스트 코드 전부 통과는 확인했습니다! 그런데 클릭하우스 에러 콘솔 찍히는 게 신경쓰여 아래 코드 넣어봤는데, 여전히 출력되고 어떤 레포지토리에서 나오는지 모르겠더라고요. 이미 expect에서 throw되는지는 확인하고 있으니 전부 적용해보면 어떨까요?? 
  ```
        jest.spyOn(console, 'error').mockImplementation(() => {});
  ``` 


### 📷 스크린샷 또는 GIF
- 직전 히루(24시간) - 1분 단위
  ![image](https://github.com/user-attachments/assets/f0635a44-75f0-4968-b708-3ba69d872b26)
- 직전 1주일 - 15분 단위
  ![Screenshot 2024-11-26 at 11 01 22 AM](https://github.com/user-attachments/assets/ee33e02c-1be3-4a1a-849e-bf729615a32c)
- 직전 1개월 - 1시간 단위
  ![Screenshot 2024-11-26 at 10 59 11 AM](https://github.com/user-attachments/assets/dcd5c7fa-c342-4aee-806a-ead997085242)

