### PR TITLE
[BE] 프로젝명 유효성 검사 API 구현

### DIFF
--- a/backend/console-server/src/clickhouse/util/metric-expressions.ts
+++ b/backend/console-server/src/clickhouse/util/metric-expressions.ts
@@ -1,6 +1,6 @@
 export const metricExpressions: Record<string, MetricFunction> = {
     avg: (metric: string) => `avg(${metric}) as avg_${metric}`,
-    count: () => `count() as count`,
+    count: () => `toUInt32(count()) as count`,
     sum: (metric: string) => `sum(${metric}) as sum_${metric}`,
     min: (metric: string) => `min(${metric}) as min_${metric}`,
     max: (metric: string) => `max(${metric}) as max_${metric}`,

--- a/backend/console-server/src/log/rank/dto/get-traffic-rank-response.dto.ts
+++ b/backend/console-server/src/log/rank/dto/get-traffic-rank-response.dto.ts
@@ -1,0 +1,38 @@
+import { IsNumber, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class TrafficRank {
+    @IsString()
+    projectName: string;
+
+    @IsNumber()
+    count: number;
+}
+
+export class GetTrafficRankResponseDto {
+    @ApiProperty({
+        description: '총 갯수',
+        example: 30,
+    })
+    @IsNumber()
+    total: number;
+
+    @ApiProperty({
+        description: '응답 성공률 순위',
+        example: [
+            {
+                projectName: 'test059',
+                count: 10000,
+            },
+            {
+                projectName: 'test007',
+                count: 9999,
+            },
+            {
+                projectName: 'test079',
+                count: 9898,
+            },
+        ],
+    })
+    rank: TrafficRank[];
+}

--- a/backend/console-server/src/log/rank/dto/get-traffic-rank.dto.ts
+++ b/backend/console-server/src/log/rank/dto/get-traffic-rank.dto.ts
@@ -1,0 +1,13 @@
+import { Expose, Type } from 'class-transformer';
+import { IsNumber } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetTrafficRankDto {
+    @ApiProperty({
+        example: '9',
+    })
+    @Type(() => Number)
+    @IsNumber()
+    @Expose()
+    generation: number;
+}

--- a/backend/console-server/src/log/rank/metric/host-count.metric.ts
+++ b/backend/console-server/src/log/rank/metric/host-count.metric.ts
@@ -1,11 +1,11 @@
 import { Type } from 'class-transformer';
 import { IsNumber, IsString } from 'class-validator';
 
-export class HostErrorRateMetric {
+export class HostCountMetric {
     @IsString()
     host: string;
 
     @Type(() => Number)
     @IsNumber()
-    is_error_rate: number;
+    count: number;
 }

--- a/backend/console-server/src/log/rank/rank.controller.spec.ts
+++ b/backend/console-server/src/log/rank/rank.controller.spec.ts
@@ -1,8 +1,11 @@
-import { Test, TestingModule } from '@nestjs/testing';
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
 import { RankController } from './rank.controller';
 import { RankService } from './rank.service';
-import { GetSuccessRateRankDto } from './dto/get-success-rate-rank.dto';
-import { HttpStatus } from '@nestjs/common';
+import type { GetSuccessRateRankDto } from './dto/get-success-rate-rank.dto';
+import type { GetSuccessRateRankResponseDto } from './dto/get-success-rate-rank-response.dto';
+import type { GetTrafficRankDto } from './dto/get-traffic-rank.dto';
+import type { GetTrafficRankResponseDto } from './dto/get-traffic-rank-response.dto';
 
 describe('RankController', () => {
     let controller: RankController;
@@ -10,6 +13,7 @@ describe('RankController', () => {
 
     const mockRankService = {
         getSuccessRateRank: jest.fn(),
+        getTrafficRank: jest.fn(),
     };
 
     beforeEach(async () => {
@@ -32,26 +36,30 @@ describe('RankController', () => {
     });
 
     describe('RankController의', () => {
-        const mockDto: GetSuccessRateRankDto = {
-            generation: 1,
-        };
-
-        const mockResponse = {
-            rankings: [
-                {
-                    rank: 1,
-                    teamName: 'Team A',
-                    successRate: 98.5,
-                },
-                {
-                    rank: 2,
-                    teamName: 'Team B',
-                    successRate: 97.2,
-                },
-            ],
-        };
-
         describe('getSuccessRateRank()는', () => {
+            let mockDto: GetSuccessRateRankDto;
+            let mockResponse: GetSuccessRateRankResponseDto;
+
+            beforeEach(async () => {
+                mockDto = {
+                    generation: 1,
+                };
+
+                mockResponse = {
+                    total: 2,
+                    rank: [
+                        {
+                            projectName: 'watchducks001',
+                            successRate: 98.5,
+                        },
+                        {
+                            projectName: 'watchducks002',
+                            successRate: 97.2,
+                        },
+                    ],
+                };
+            });
+
             it('정의되어 있어야 한다', () => {
                 expect(controller).toBeDefined();
             });
@@ -72,6 +80,53 @@ describe('RankController', () => {
 
                 await expect(controller.getSuccessRateRank(mockDto)).rejects.toThrow(error);
                 expect(service.getSuccessRateRank).toHaveBeenCalledWith(mockDto);
+            });
+        });
+
+        describe('getTrafficRank()는', () => {
+            let mockDto: GetTrafficRankDto;
+            let mockResponse: GetTrafficRankResponseDto;
+
+            beforeEach(async () => {
+                mockDto = {
+                    generation: 1,
+                };
+
+                mockResponse = {
+                    total: 2,
+                    rank: [
+                        {
+                            projectName: 'watchducks001',
+                            count: 10000,
+                        },
+                        {
+                            projectName: 'watchducks002',
+                            count: 9998,
+                        },
+                    ],
+                };
+            });
+
+            it('정의되어 있어야 한다', () => {
+                expect(controller).toBeDefined();
+            });
+
+            it('트래픽 랭킹 데이터를 반환해야 한다', async () => {
+                mockRankService.getTrafficRank.mockResolvedValue(mockResponse);
+
+                const result = await controller.getTrafficRank(mockDto);
+
+                expect(result).toBe(mockResponse);
+                expect(service.getTrafficRank).toHaveBeenCalledWith(mockDto);
+                expect(service.getTrafficRank).toHaveBeenCalledTimes(1);
+            });
+
+            it('서비스 계층에서 오류가 발생하면 해당 오류를 그대로 던져야 한다', async () => {
+                const error = new Error('Service error');
+                mockRankService.getTrafficRank.mockRejectedValue(error);
+
+                await expect(controller.getTrafficRank(mockDto)).rejects.toThrow(error);
+                expect(service.getTrafficRank).toHaveBeenCalledWith(mockDto);
             });
         });
     });

--- a/backend/console-server/src/log/rank/rank.controller.ts
+++ b/backend/console-server/src/log/rank/rank.controller.ts
@@ -3,6 +3,7 @@ import { Controller, Get, HttpCode, HttpStatus, Query } from '@nestjs/common';
 import { GetSuccessRateRankResponseDto } from './dto/get-success-rate-rank-response.dto';
 import { GetSuccessRateRankDto } from './dto/get-success-rate-rank.dto';
 import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { GetTrafficRankDto } from './dto/get-traffic-rank.dto';
 
 @Controller('log/rank')
 export class RankController {
@@ -21,5 +22,20 @@ export class RankController {
     })
     async getSuccessRateRank(@Query() getSuccessRateRankDto: GetSuccessRateRankDto) {
         return await this.rankService.getSuccessRateRank(getSuccessRateRankDto);
+    }
+
+    @Get('/traffic')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: '기수 내 트래픽 랭킹',
+        description: '요청받은 기수의 기수 내 트래픽 랭킹을 반환합니다.',
+    })
+    @ApiResponse({
+        status: HttpStatus.OK,
+        description: '기수 내 트래픽 랭킹이 성공적으로 반환됨.',
+        type: GetTrafficRankDto,
+    })
+    async getTrafficRank(@Query() getTrafficRankDto: GetTrafficRankDto) {
+        return await this.rankService.getTrafficRank(getTrafficRankDto);
     }
 }

--- a/backend/console-server/src/log/rank/rank.repository.spec.ts
+++ b/backend/console-server/src/log/rank/rank.repository.spec.ts
@@ -3,7 +3,6 @@ import { Test } from '@nestjs/testing';
 import { RankRepository } from './rank.repository';
 import { Clickhouse } from '../../clickhouse/clickhouse';
 import { TimeSeriesQueryBuilder } from '../../clickhouse/query-builder/time-series.query-builder';
-import { HostErrorRateMetric } from './metric/host-error-rate.metric';
 
 jest.mock('../../clickhouse/query-builder/time-series.query-builder');
 
@@ -75,16 +74,17 @@ describe('RankRepository', () => {
                 );
             });
 
-            it('조회 결과를 HostErrorRateMetric 인스턴스로 변환하여 반환해야 한다', async () => {
+            it('조회 결과는 HostErrorRateMetric 객체 타입을 가져야한다', async () => {
                 mockClickhouse.query.mockResolvedValue(mockResults);
 
-                const result = await repository.findSuccessRateOrderByCount();
+                const results = await repository.findSuccessRateOrderByCount();
 
-                expect(result).toHaveLength(mockResults.length);
-                result.forEach((item, index) => {
-                    expect(item).toBeInstanceOf(HostErrorRateMetric);
-                    expect(item.host).toBe(mockResults[index].host);
-                    expect(item.is_error_rate).toBe(mockResults[index].is_error_rate);
+                expect(results).toHaveLength(mockResults.length);
+                results.forEach((result, index) => {
+                    expect(typeof result.host).toBe('string');
+                    expect(typeof result.is_error_rate).toBe('number');
+                    expect(result.host).toBe(mockResults[index].host);
+                    expect(result.is_error_rate).toBe(mockResults[index].is_error_rate);
                 });
             });
 
@@ -93,6 +93,68 @@ describe('RankRepository', () => {
                 mockClickhouse.query.mockRejectedValue(error);
 
                 await expect(repository.findSuccessRateOrderByCount()).rejects.toThrow(error);
+            });
+        });
+
+        describe('findCountOrderByCount()는', () => {
+            const mockQueryResult = {
+                query: 'SELECT host, count() as count FROM http_log GROUP BY host ORDER BY count',
+                params: {},
+            };
+
+            const mockResults = [
+                { host: 'test1.com', count: 9999 },
+                { host: 'test2.com', count: 9898 },
+            ];
+
+            beforeEach(() => {
+                (TimeSeriesQueryBuilder as jest.Mock).mockImplementation(() => ({
+                    metrics: jest.fn().mockReturnThis(),
+                    from: jest.fn().mockReturnThis(),
+                    groupBy: jest.fn().mockReturnThis(),
+                    orderBy: jest.fn().mockReturnThis(),
+                    build: jest.fn().mockReturnValue(mockQueryResult),
+                }));
+            });
+
+            it('TimeSeriesQueryBuilder를 사용하여 쿼리를 생성해야 한다', async () => {
+                mockClickhouse.query.mockResolvedValue(mockResults);
+
+                await repository.findCountOrderByCount();
+
+                expect(TimeSeriesQueryBuilder).toHaveBeenCalled();
+            });
+
+            it('생성된 쿼리로 Clickhouse를 호출해야 한다', async () => {
+                mockClickhouse.query.mockResolvedValue(mockResults);
+
+                await repository.findCountOrderByCount();
+
+                expect(clickhouse.query).toHaveBeenCalledWith(
+                    mockQueryResult.query,
+                    mockQueryResult.params,
+                );
+            });
+
+            it('조회 결과는 HostCountMetric 객체 타입을 가져야한다', async () => {
+                mockClickhouse.query.mockResolvedValue(mockResults);
+
+                const results = await repository.findCountOrderByCount();
+
+                expect(results).toHaveLength(mockResults.length);
+                results.forEach((result, index) => {
+                    expect(typeof result.host).toBe('string');
+                    expect(typeof result.count).toBe('number');
+                    expect(result.host).toBe(mockResults[index].host);
+                    expect(result.count).toBe(mockResults[index].count);
+                });
+            });
+
+            it('Clickhouse 쿼리 실패 시 에러를 전파해야 한다', async () => {
+                const error = new Error('Clickhouse query failed');
+                mockClickhouse.query.mockRejectedValue(error);
+
+                await expect(repository.findCountOrderByCount()).rejects.toThrow(error);
             });
         });
     });

--- a/backend/console-server/src/log/rank/rank.repository.ts
+++ b/backend/console-server/src/log/rank/rank.repository.ts
@@ -2,6 +2,7 @@ import { Clickhouse } from '../../clickhouse/clickhouse';
 import { Injectable } from '@nestjs/common';
 import { TimeSeriesQueryBuilder } from '../../clickhouse/query-builder/time-series.query-builder';
 import { HostErrorRateMetric } from './metric/host-error-rate.metric';
+import { HostCountMetric } from './metric/host-count.metric';
 
 @Injectable()
 export class RankRepository {
@@ -16,5 +17,16 @@ export class RankRepository {
             .build();
 
         return await this.clickhouse.query<HostErrorRateMetric>(query, params);
+    }
+
+    async findCountOrderByCount() {
+        const { query, params } = new TimeSeriesQueryBuilder()
+            .metrics([{ name: 'host' }, { name: '*', aggregation: 'count' }])
+            .from('http_log')
+            .groupBy(['host'])
+            .orderBy(['count'], true)
+            .build();
+
+        return await this.clickhouse.query<HostCountMetric>(query, params);
     }
 }

--- a/backend/console-server/src/log/traffic/dto/get-traffic-top5-response.dto.ts
+++ b/backend/console-server/src/log/traffic/dto/get-traffic-top5-response.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Expose } from 'class-transformer';
 import { TrafficRankMetric } from '../metric/traffic-rank.metric';
 
-export class GetTrafficRankResponseDto {
+export class GetTrafficTop5ResponseDto {
     @ApiProperty({
         example: [
             { host: 'watchducks01', count: 100 },

--- a/backend/console-server/src/log/traffic/traffic.controller.ts
+++ b/backend/console-server/src/log/traffic/traffic.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Get, HttpCode, HttpStatus, Query } from '@nestjs/common';
 import { ApiOperation, ApiResponse } from '@nestjs/swagger';
-import { GetTrafficRankResponseDto } from './dto/get-traffic-rank-response.dto';
+import { GetTrafficTop5ResponseDto } from './dto/get-traffic-top5-response.dto';
 import { GetTrafficTop5Dto } from './dto/get-traffic-top5.dto';
 import { GetTrafficByProjectResponseDto } from './dto/get-traffic-by-project-response.dto';
 import { GetTrafficByProjectDto } from './dto/get-traffic-by-project.dto';
@@ -25,7 +25,7 @@ export class TrafficController {
     @ApiResponse({
         status: HttpStatus.OK,
         description: '트래픽 랭킹 TOP 5가 정상적으로 반환됨.',
-        type: GetTrafficRankResponseDto,
+        type: GetTrafficTop5ResponseDto,
     })
     async getTrafficTop5(@Query() getTrafficTop5Dto: GetTrafficTop5Dto) {
         return await this.trafficService.getTrafficTop5(getTrafficTop5Dto);

--- a/backend/console-server/src/log/traffic/traffic.repository.spec.ts
+++ b/backend/console-server/src/log/traffic/traffic.repository.spec.ts
@@ -83,10 +83,9 @@ describe('TrafficRepository 테스트', () => {
 
             expect(result).toEqual(mockTrafficData);
             expect(clickhouse.query).toHaveBeenCalledWith(
-                expect.stringMatching(
-                    /SELECT\s+count\(\)\s+as\s+count,\s+toStartOfHour\(timestamp\)\s+as\s+timestamp\s+FROM\s+http_log\s+WHERE\s+host\s+=\s+\{host:String}\s+GROUP\s+BY\s+timestamp\s+ORDER\s+BY\s+timestamp/s,
-                ),
-                expect.objectContaining({ host: domain }),
+                `SELECT toUInt32(count()) as count, toStartOfHour(timestamp) as timestamp
+FROM http_log WHERE host = {host:String} GROUP BY timestamp ORDER BY timestamp`,
+                { host: 'example.com' },
             );
         });
 

--- a/backend/console-server/src/log/traffic/traffic.service.ts
+++ b/backend/console-server/src/log/traffic/traffic.service.ts
@@ -1,6 +1,6 @@
 import type { GetTrafficTop5Dto } from './dto/get-traffic-top5.dto';
 import { plainToInstance } from 'class-transformer';
-import { GetTrafficRankResponseDto } from './dto/get-traffic-rank-response.dto';
+import { GetTrafficTop5ResponseDto } from './dto/get-traffic-top5-response.dto';
 import type { GetTrafficByGenerationDto } from './dto/get-traffic-by-generation.dto';
 import { GetTrafficByGenerationResponseDto } from './dto/get-traffic-by-generation-response.dto';
 import type { GetTrafficDailyDifferenceDto } from './dto/get-traffic-daily-difference.dto';
@@ -32,7 +32,7 @@ export class TrafficService {
     async getTrafficTop5(_getTrafficTop5Dto: GetTrafficTop5Dto) {
         const result = await this.trafficRepository.findTop5CountByHost();
 
-        return plainToInstance(GetTrafficRankResponseDto, result);
+        return plainToInstance(GetTrafficTop5ResponseDto, result);
     }
 
     async getTrafficByGeneration(_getTrafficByGenerationDto: GetTrafficByGenerationDto) {

--- a/backend/console-server/src/project/dto/exists-project-response.dto.ts
+++ b/backend/console-server/src/project/dto/exists-project-response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { IsBoolean } from 'class-validator';
+
+export class ExistsProjectResponseDto {
+    @ApiProperty({
+        example: true,
+    })
+    @IsBoolean()
+    @Expose()
+    exists: boolean;
+}

--- a/backend/console-server/src/project/dto/exists-project.dto.ts
+++ b/backend/console-server/src/project/dto/exists-project.dto.ts
@@ -1,0 +1,11 @@
+import { IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ExistsProjectDto {
+    @IsString()
+    @ApiProperty({
+        example: 'watchducks',
+        description: '유효성 검사할 프로젝트 명',
+    })
+    projectName: string;
+}

--- a/backend/console-server/src/project/project.controller.spec.ts
+++ b/backend/console-server/src/project/project.controller.spec.ts
@@ -4,12 +4,14 @@ import { ProjectController } from './project.controller';
 import { ProjectService } from './project.service';
 import type { CreateProjectDto } from './dto/create-project.dto';
 import { ConflictException } from '@nestjs/common';
+import type { ExistsProjectDto } from './dto/exists-project.dto';
 
 describe('ProjectController의', () => {
     let projectController: ProjectController;
 
     const mockProjectService = {
         create: jest.fn(),
+        existsProject: jest.fn(),
     };
 
     beforeEach(async () => {
@@ -51,6 +53,32 @@ describe('ProjectController의', () => {
                 ConflictException,
             );
             expect(mockProjectService.create).toHaveBeenCalledWith(createProjectDto);
+        });
+    });
+
+    describe('existsProject()는', () => {
+        const existsProjectDto: ExistsProjectDto = {
+            projectName: 'watchducks',
+        };
+
+        it('유효한 프로젝트명 요청에 대해 true를 응답해야합니다.', async () => {
+            const result = { exists: true };
+            (mockProjectService.existsProject as jest.Mock).mockReturnValue(result);
+
+            const response = await projectController.existProject(existsProjectDto);
+
+            expect(response).toEqual(result);
+            expect(mockProjectService.existsProject).toHaveBeenCalledWith(existsProjectDto);
+        });
+
+        it('유효한 프로젝트명 요청에 대해 false를 응답해야합니다.', async () => {
+            const result = { exists: false };
+            (mockProjectService.existsProject as jest.Mock).mockReturnValue(result);
+
+            const response = await projectController.existProject(existsProjectDto);
+
+            expect(response).toEqual(result);
+            expect(mockProjectService.existsProject).toHaveBeenCalledWith(existsProjectDto);
         });
     });
 });

--- a/backend/console-server/src/project/project.controller.ts
+++ b/backend/console-server/src/project/project.controller.ts
@@ -9,6 +9,8 @@ import { ProjectResponseDto } from './dto/create-project-response.dto';
 import { CountProjectByGenerationDto } from './dto/count-project-by-generation.dto';
 import { FindByGenerationResponseDto } from './dto/find-by-generation-response.dto';
 import { CountProjectByGenerationResponseDto } from './dto/count-project-by-generation-response.dto';
+import { ExistsProjectDto } from './dto/exists-project.dto';
+import { ExistsProjectResponseDto } from './dto/exists-project-response.dto';
 
 @Controller('project')
 export class ProjectController {
@@ -58,5 +60,20 @@ export class ProjectController {
         @Query() countProjectByGenerationDto: CountProjectByGenerationDto,
     ) {
         return await this.projectService.countProjectByGeneration(countProjectByGenerationDto);
+    }
+
+    @Get('/exists')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: '프로젝트명 유효성 검사',
+        description: '요청받은 프로젝트명에 대한 유효성 검사 결과를 반환합니다.',
+    })
+    @ApiResponse({
+        status: 200,
+        description: '프로젝트명이 유효성 검사 결과가 반환됨',
+        type: ExistsProjectResponseDto,
+    })
+    async existProject(@Query() existsProjectDto: ExistsProjectDto) {
+        return await this.projectService.existsProject(existsProjectDto);
     }
 }

--- a/backend/console-server/src/project/project.service.ts
+++ b/backend/console-server/src/project/project.service.ts
@@ -10,6 +10,8 @@ import { FindByGenerationDto } from './dto/find-by-generation.dto';
 import { FindByGenerationResponseDto } from './dto/find-by-generation-response.dto';
 import { CountProjectByGenerationDto } from './dto/count-project-by-generation.dto';
 import { CountProjectByGenerationResponseDto } from './dto/count-project-by-generation-response.dto';
+import { ExistsProjectDto } from './dto/exists-project.dto';
+import { ExistsProjectResponseDto } from './dto/exists-project-response.dto';
 
 @Injectable()
 export class ProjectService {
@@ -62,6 +64,14 @@ export class ProjectService {
         return plainToInstance(CountProjectByGenerationResponseDto, {
             count: count,
         });
+    }
+
+    async existsProject(existProjectDto: ExistsProjectDto) {
+        const exists = await this.projectRepository.exists({
+            where: { name: existProjectDto.projectName },
+        });
+
+        return plainToInstance(ExistsProjectResponseDto, { exists });
     }
 }
 


### PR DESCRIPTION
### 👀 관련 이슈
#180

### ✨ 작업한 내용
🚀  프로젝트명 유효성 검사 API 구현

#### 쿼리
```typescript
const exists = await this.projectRepository.exists({
            where: { name: existProjectDto.projectName },
        });
```

#### 엔드포인트
`GET /api/project/exists`

#### ResponseBody 예시
```json
{
    "exists": true
}
```

### 🌀 PR Point

### 🍰 참고사항

### 📷 스크린샷 또는 GIF
<img width="329" alt="스크린샷 2024-11-26 오후 6 52 26" src="https://github.com/user-attachments/assets/5e6b6668-fb3b-4dc4-8cd4-ea43f1c4c793">


