### PR TITLE
[BE] 트래픽 TOP5 프로젝트의 작일 트래픽 차트 데이터 API 테스트 케이스 작성

### DIFF
--- a/backend/console-server/src/log/traffic/traffic.service.ts
+++ b/backend/console-server/src/log/traffic/traffic.service.ts
@@ -111,11 +111,10 @@ export class TrafficService {
         const trafficCharts = await Promise.all(
             results.map(async (result) => {
                 const host = result.host;
-                const project = await this.projectRepository
-                    .createQueryBuilder('project')
-                    .select('project.name')
-                    .where('project.domain = :domain', { domain: host })
-                    .getOne();
+                const project = await this.projectRepository.findOne({
+                    select: ['name'],
+                    where: { domain: host },
+                });
 
                 const projectName = project?.name;
 
@@ -126,6 +125,6 @@ export class TrafficService {
             }),
         );
 
-        return plainToInstance(GetTrafficTop5ChartResponseDto, trafficCharts);
+        return plainToInstance(GetTrafficTop5ChartResponseDto, { trafficCharts });
     }
 }

--- a/backend/console-server/src/project/project.service.ts
+++ b/backend/console-server/src/project/project.service.ts
@@ -15,8 +15,6 @@ import { ExistsProjectResponseDto } from './dto/exists-project-response.dto';
 
 @Injectable()
 export class ProjectService {
-    private readonly BASE_YEAR: number = 2015;
-
     constructor(
         @InjectRepository(Project)
         private readonly projectRepository: Repository<Project>,


### PR DESCRIPTION
### 👀 관련 이슈
#185 

### ✨ 작업한 내용
🚀  Service
- 트래픽 TOP 5 차트 데이터를 정상적으로 반환해야 한다
- 프로젝트가 존재하지 않는 경우 name이 undefined인 데이터를 반환해야 한다
- 트래픽 데이터가 없는 경우 빈 배열을 반환해야 한다
- repository 에러 발생 시 에러를 전파해야 한다

🚀  Controller
- Top5 트래픽 차트 데이터를 반환해야한다
- 데이터가 빈 배열이어도 처리할 수 있어야한다
- 서비스에서 에러가 발생할 경우 에러를 발생시켜야한다

🚀  프로젝트의 host로 name쿼리하는 코드 리팩터링
- 쿼리빌더 -> findOne 메서드

### 📷 스크린샷 또는 GIF
![스크린샷 2024-11-27 오전 12 17 04](https://github.com/user-attachments/assets/d3b281db-0764-4134-b94a-879442a2e255)
![스크린샷 2024-11-27 오전 12 17 28](https://github.com/user-attachments/assets/525ecf5f-3a87-4048-bfe6-544ebd99fbf9)
