### PR TITLE
[FE] 개별 프로젝트페이지 일부완성, 에러페이지 완성

### DIFF
--- a/front/eslint.config.js
+++ b/front/eslint.config.js
@@ -32,6 +32,7 @@ export default [
       '@tanstack/query': tanstackQuery
     },
     rules: {
+      'react/prop-types': 'off',
       '@tanstack/query/exhaustive-deps': 'warn',
       'react/react-in-jsx-scope': 'off',
       'react/jsx-uses-react': 'off',

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,10 +1,11 @@
+import MainBoundary from '@boundary/MainBoundary';
+import ErrorPage from '@component/page/ErrorPage';
 import MainPage from '@component/page/MainPage';
+import ProjectDetailPage from '@component/page/ProjectDetailPage';
 import ProjectPage from '@component/page/ProjectPage';
 import RankingPage from '@component/page/RankingPage';
 import RegisterPage from '@component/page/RegisterPage';
 import { Routes, Route } from 'react-router-dom';
-
-import MainBoundary from './boundary/MainBoundary';
 
 function App() {
   return (
@@ -12,9 +13,11 @@ function App() {
       <Route element={<MainBoundary />}>
         <Route path='/' element={<MainPage />} />
         <Route path='/project' element={<ProjectPage />} />
+        <Route path='/project/:id' element={<ProjectDetailPage />} />
         <Route path='/ranking' element={<RankingPage />} />
       </Route>
       <Route path='/register' element={<RegisterPage />} />
+      <Route path='*' element={<ErrorPage />} />
     </Routes>
   );
 }

--- a/front/src/api/axios.ts
+++ b/front/src/api/axios.ts
@@ -13,10 +13,6 @@ const api = {
   post: async <T, P>(url: string, data: P): Promise<AxiosResponse<T>> => {
     return $axios.post<T>(url, data);
   },
-
-  patch: async <T, P>(url: string, data: P): Promise<AxiosResponse<T>> => {
-    return $axios.patch<T>(url, data);
-  }
 };
 
 export { api };

--- a/front/src/api/get.ts
+++ b/front/src/api/get.ts
@@ -5,7 +5,12 @@ import {
   DailyDifferenceTraffic,
   ElapsedTime,
   ResponseTime,
-  Top5Traffic
+  Top5Traffic,
+  ProjectElapsedTime,
+  ProjectSuccessRate,
+  ProjectDAU,
+  ProjectTraffic,
+  ProjectExist
 } from '@type/api';
 import { GroupOption } from '@type/Navbar';
 
@@ -24,7 +29,7 @@ const getRankings = async (generation: string) => {
   return response.data;
 };
 
-const getTotalTraffic = async (generation: string) => {
+const getTotalTrafficCount = async (generation: string) => {
   const response = await api.get<Traffic>(`/log/traffic?generation=${generation}`);
   return response.data;
 };
@@ -57,20 +62,56 @@ const getTop5ResponseTime = async (generation: string) => {
 };
 
 const getTop5Traffic = async (generation: string) => {
-  const response = await api.get<Top5Traffic[]>(
+  const response = await api.get<Top5Traffic>(
     `/log/traffic/top5/line-chart?generation=${generation}`
   );
   return response.data;
 };
 
+const getSuccessRate = async (project: string) => {
+  const response = await api.get<ProjectSuccessRate>(
+    `/log/success-rate/project?projectName=${project}`
+  );
+  return response.data;
+};
+
+const getDAU = async (project: string) => {
+  const response = await api.get<ProjectDAU>(`/log/analytics/dau?projectName=${project}`);
+  return response.data;
+};
+
+const getElapsedTime = async (project: string) => {
+  const response = await api.get<ProjectElapsedTime>(
+    `/log/elapsed-time/path-rank?projectName=${project}`
+  );
+  return response.data;
+};
+
+const getTraffic = async (project: string, dateType: string) => {
+  const response = await api.get<ProjectTraffic>(
+    `/log/traffic/project?projectName=${project}&timeUnit=${dateType}`
+  );
+  return response.data;
+};
+
+const getIsExistProject = async (project: string) => {
+  const response = await api.get<ProjectExist>(`/project/exists?projectName=${project}`);
+  return response.data;
+};
+
 export {
+  getIsExistProject,
   getGroupNames,
   getRankings,
-  getTotalTraffic,
+  getTotalTrafficCount,
   getTotalProjectCount,
   getTotalResponseRate,
   getDailyDifferenceTraffic,
   getTotalElapsedTime,
   getTop5ResponseTime,
-  getTop5Traffic
+  getTop5Traffic,
+  getSuccessRate,
+  getDAU,
+  getElapsedTime,
+  getTraffic
 };

--- a/front/src/boundary/CustomQueryProvider.tsx
+++ b/front/src/boundary/CustomQueryProvider.tsx
@@ -7,11 +7,7 @@ type Props = {
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      retry: 1,
       staleTime: 5 * 60 * 1000
-    },
-    mutations: {
-      retry: 1
     }
   }
 });

--- a/front/src/boundary/MainBoundary.tsx
+++ b/front/src/boundary/MainBoundary.tsx
@@ -4,15 +4,22 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useState } from 'react';
 import { Outlet } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 export default function MainBoundary() {
+  const navigate = useNavigate();
   const [generation, setGeneration] = useState<string>(GENERATION_VALUE.NINTH);
   const [selectedGroup, setSelectedGroup] = useState<string>(BOOST_CAMP_OPTION[0].value);
   const [isNavbarOpen, setIsNavbarOpen] = useState<boolean>(true);
   const [isHovered, setIsHovered] = useState<boolean>(false);
 
+  const handleSelectGroup = (value: string) => {
+    setSelectedGroup(value);
+    navigate(`/project/${value}`);
+  };
+
   return (
-    <div className='flex min-h-screen bg-gray-50'>
+    <div className='bg-gray-50 flex min-h-screen'>
       <div
         className='relative'
         onMouseEnter={() => setIsHovered(true)}
@@ -24,12 +31,12 @@ export default function MainBoundary() {
               animate={{ width: '300px', opacity: 1, x: 0 }}
               exit={{ width: 0, opacity: 0, x: -50 }}
               transition={{ duration: 0.3, ease: 'easeInOut' }}
-              className='border-r border-gray-200'>
+              className='border-gray-200 border-r'>
               <Navbar
                 generation={generation}
                 selectedGroup={selectedGroup}
                 setGeneration={setGeneration}
-                setSelectedGroup={setSelectedGroup}
+                setSelectedGroup={handleSelectGroup}
               />
               {isHovered && (
                 <motion.button
@@ -38,7 +45,7 @@ export default function MainBoundary() {
                   exit={{ opacity: 0 }}
                   transition={{ duration: 0.3 }}
                   onClick={() => setIsNavbarOpen(false)}
-                  className='absolute right-[-20px] top-1/3 z-10 rounded-full bg-white p-2 shadow-md hover:bg-gray-50'
+                  className='hover:bg-gray-50 absolute right-[-20px] top-1/3 z-10 rounded-full bg-white p-2 shadow-md'
                   style={{ transform: 'translateY(-50%)' }}>
                   <ChevronLeft size={20} />
                 </motion.button>
@@ -54,7 +61,7 @@ export default function MainBoundary() {
             exit={{ opacity: 0 }}
             transition={{ duration: 0.3 }}
             onClick={() => setIsNavbarOpen(true)}
-            className='fixed left-4 top-1/3 z-10 rounded-full bg-white p-2 shadow-md hover:bg-gray-50'
+            className='hover:bg-gray-50 fixed left-4 top-1/3 z-10 rounded-full bg-white p-2 shadow-md'
             style={{ transform: 'translateY(-50%)' }}>
             <ChevronRight size={20} />
           </motion.button>

--- a/front/src/chart/BarChart.tsx
+++ b/front/src/chart/BarChart.tsx
@@ -7,7 +7,7 @@ type Props = {
   options: ApexCharts.ApexOptions;
 };
 
-export function BarChart({ series, options: additionalOptions }: Props) {
+export default function BarChart({ series, options: additionalOptions }: Props) {
   const barChartOptions: ApexCharts.ApexOptions = {
     chart: {
       height: '100%',

--- a/front/src/chart/LineChart.tsx
+++ b/front/src/chart/LineChart.tsx
@@ -1,4 +1,4 @@
-import { CHART_COLORS } from '@constant/ChartColors';
+import { CHART_COLORS } from '@constant/Chart';
 import { DATE_FORMAT_OPTIONS, TIME_FORMAT_OPTIONS } from '@constant/Time';
 import { merge } from 'lodash-es';
 
@@ -9,7 +9,7 @@ type Props = {
   options: ApexCharts.ApexOptions;
 };
 
-export function LineChart({ series, options: additionalOptions }: Props) {
+export default function LineChart({ series, options: additionalOptions }: Props) {
   const lineChartOption: ApexCharts.ApexOptions = {
     chart: {
       height: 350,

--- a/front/src/chart/PieChart.tsx
+++ b/front/src/chart/PieChart.tsx
@@ -1,0 +1,25 @@
+import { CHART_COLORS } from '@constant/Chart';
+import { merge } from 'lodash-es';
+
+import { Chart } from './Chart';
+
+type Props = {
+  series: number[];
+  options: ApexCharts.ApexOptions;
+};
+
+export default function PieChart({ series, options: additionalOptions }: Props) {
+  const donutChartOption: ApexCharts.ApexOptions = {
+    chart: {
+      height: 350,
+      type: 'donut'
+    },
+    legend: {
+      position: 'bottom'
+    },
+    colors: CHART_COLORS
+  };
+
+  const options = merge({}, donutChartOption, additionalOptions);
+  return <Chart type='donut' series={series} options={options} />;
+}

--- a/front/src/chart/PolarAreaChart.tsx
+++ b/front/src/chart/PolarAreaChart.tsx
@@ -1,0 +1,33 @@
+import { merge } from 'lodash-es';
+
+import { Chart } from './Chart';
+
+type Props = {
+  series: number[];
+  options: ApexCharts.ApexOptions;
+};
+
+export default function PolarAreaChart({ series, options: additionalOptions }: Props) {
+  console.log(series);
+  const PolarChartOption: ApexCharts.ApexOptions = {
+    chart: {
+      type: 'polarArea',
+      height: 350
+    },
+    plotOptions: {
+      polarArea: {
+        rings: {
+          strokeWidth: 1,
+          strokeColor: '#e8e8e8'
+        },
+        spokes: {
+          strokeWidth: 1,
+          connectorColors: '#e8e8e8'
+        }
+      }
+    }
+  };
+
+  const options = merge({}, PolarChartOption, additionalOptions);
+  return <Chart type='polarArea' series={series} options={options} />;
+}

--- a/front/src/chart/PolarAreaChart.tsx
+++ b/front/src/chart/PolarAreaChart.tsx
@@ -8,7 +8,6 @@ type Props = {
 };
 
 export default function PolarAreaChart({ series, options: additionalOptions }: Props) {
-  console.log(series);
   const PolarChartOption: ApexCharts.ApexOptions = {
     chart: {
       type: 'polarArea',

--- a/front/src/component/atom/Span.tsx
+++ b/front/src/component/atom/Span.tsx
@@ -1,8 +1,13 @@
 type Props = {
   cssOption?: string;
-  content: string;
+  content?: string;
+  style?: React.CSSProperties;
 };
 
-export default function Span({ cssOption, content = '' }: Props) {
-  return <span className={cssOption}>{content}</span>;
+export default function Span({ cssOption, content, style }: Props) {
+  return (
+    <span className={cssOption} style={style}>
+      {content}
+    </span>
+  );
 }

--- a/front/src/component/molecule/NavbarCustomSelect.tsx
+++ b/front/src/component/molecule/NavbarCustomSelect.tsx
@@ -1,17 +1,26 @@
+import NavbarSelect from '@component/molecule/NavbarSelect';
 import useGroupNames from '@hook/api/useGroupNames';
 import { NavbarSelectProps } from '@type/Navbar';
-import { useEffect } from 'react';
-
-import NavbarSelect from './NavbarSelect';
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
 
 type Props = NavbarSelectProps;
 
 export default function NavbarCustomSelect(props: Props) {
   const { data = [] } = useGroupNames(props.generation);
+  const location = useLocation();
+  const projectGroup = location.pathname.split('/project/')[1];
+  const initializedRef = useRef<boolean>(false);
 
   useEffect(() => {
-    props.setSelectedGroup(data[0].value);
-  }, [data]);
+    if (!initializedRef.current && data.length > 0) {
+      const groupToSelect =
+        projectGroup && data.some((g) => g.value === projectGroup) ? projectGroup : data[0]?.value;
+
+      props.setSelectedGroup(groupToSelect);
+      initializedRef.current = true;
+    }
+  }, [data, props.setSelectedGroup, projectGroup]);
 
   return <NavbarSelect {...props} groupOption={data} />;
 }

--- a/front/src/component/molecule/NavbarMenu.tsx
+++ b/front/src/component/molecule/NavbarMenu.tsx
@@ -32,7 +32,11 @@ export default function NavbarMenu() {
     <div className='flex flex-col gap-8 md:gap-16'>
       <H1 cssOption='mt-8 text-14 md:text-16 whitespace-nowrap dark:text-white' content='MENU' />
       {MENU_ITEMS.map((item) => (
-        <MenuItem key={item.path} item={item} isActive={pathname === item.path} />
+        <MenuItem
+          key={item.path}
+          item={item}
+          isActive={item.path === '/' ? pathname === '/' : pathname.startsWith(item.path)}
+        />
       ))}
     </div>
   );

--- a/front/src/component/molecule/NavbarRanking.tsx
+++ b/front/src/component/molecule/NavbarRanking.tsx
@@ -5,26 +5,37 @@ import { MEDALS } from '@constant/Medals';
 import useRankings from '@hook/api/useRankings';
 import { Ranking } from '@type/api';
 import { Fragment } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 type Props = {
   generation: string;
 };
 
 export default function NavbarRanking({ generation }: Props) {
+  const navigate = useNavigate();
   const { data = [] } = useRankings(generation);
+
+  const handleClick = (host: string) => {
+    navigate(`/project/${host}`);
+  };
 
   const renderRankingItem = (item: Ranking, index: number) => {
     const rank = index;
-
+    console.log(item.host);
     return (
       <Fragment key={item.host}>
-        <div className='group flex items-center justify-between gap-2 py-2 font-light hover:cursor-pointer'>
-          <div className='flex items-center gap-2'>
+        <div
+          className='group flex items-center justify-between gap-2 py-2 font-light hover:cursor-pointer'
+          onClick={() => handleClick(item.host)}>
+          <div className='flex min-w-0 flex-1 items-center gap-2'>
             {rank <= 2 ? (
               <Fragment>
-                <Img src={MEDALS[rank as keyof typeof MEDALS].image} cssOption='flex-shrink-0' />
+                <Img
+                  src={MEDALS[rank as keyof typeof MEDALS].image}
+                  cssOption='flex-shrink-0 w-6'
+                />
                 <P
-                  cssOption={`truncate ${MEDALS[rank as keyof typeof MEDALS].color}`}
+                  cssOption={`truncate ${MEDALS[rank as keyof typeof MEDALS].color} max-w-[140px]`}
                   content={item.host}
                 />
               </Fragment>
@@ -34,14 +45,14 @@ export default function NavbarRanking({ generation }: Props) {
                   cssOption='w-6 flex-shrink-0 font-medium dark:text-white'
                   content={`${rank + 1}th`}
                 />
-                <P cssOption='truncate dark:text-white' content={item.host} />
+                <P cssOption='truncate dark:text-white max-w-[140px]' content={item.host} />
               </Fragment>
             )}
           </div>
-          <div className='flex min-w-0 items-center text-right'>
+          <div className='flex items-center text-right'>
             <Span
               cssOption='text-[clamp(12px,1.5vw,14px)] group-hover:hidden dark:text-white'
-              content={item.count}
+              content={item.count.toString()}
             />
             <Span cssOption='hidden font-medium group-hover:block dark:text-white' content='&gt;' />
           </div>

--- a/front/src/component/molecule/NavbarRanking.tsx
+++ b/front/src/component/molecule/NavbarRanking.tsx
@@ -21,7 +21,7 @@ export default function NavbarRanking({ generation }: Props) {
 
   const renderRankingItem = (item: Ranking, index: number) => {
     const rank = index;
-    console.log(item.host);
+
     return (
       <Fragment key={item.host}>
         <div

--- a/front/src/component/molecule/NavbarSelect.tsx
+++ b/front/src/component/molecule/NavbarSelect.tsx
@@ -14,7 +14,7 @@ export default function NavbarSelect({
   groupOption
 }: Props) {
   const { pathname } = useLocation();
-  const isProjectPath = pathname === PATH.PROJECT;
+  const isProjectPath = pathname.includes(PATH.PROJECT);
 
   return (
     <div className='flex w-full min-w-0 items-center justify-between rounded-1.5 border-1.5 border-solid border-gray p-4 md:gap-[4px] md:p-8'>

--- a/front/src/component/molecule/ProjectElapsedTimeLegend.tsx
+++ b/front/src/component/molecule/ProjectElapsedTimeLegend.tsx
@@ -1,0 +1,34 @@
+import H2 from '@component/atom/H2';
+import Span from '@component/atom/Span';
+import { RESPONSE_TIME_LEGENDS } from '@constant/Chart';
+
+type Props = {
+  averageTime: number;
+};
+
+export default function ProjectElapsedTimeLegend({ averageTime }: Props) {
+  const getColorByTime = (time: number) => {
+    if (time <= 200) return '#4ADE80';
+    if (time <= 1000) return '#FFA500';
+    return '#FF4444';
+  };
+
+  return (
+    <div className='flex flex-col items-center gap-4'>
+      <div className='text-center'>
+        <H2 cssOption='text-navy mb-4 text-xl font-bold' content='TOP3 Average Response Speed' />
+        <div className='mb-4 text-2xl font-bold' style={{ color: getColorByTime(averageTime) }}>
+          {averageTime || 0}ms
+        </div>
+      </div>
+      <div className='text-gray-500 flex items-center justify-center gap-4 text-[10px]'>
+        {RESPONSE_TIME_LEGENDS.map((item, index) => (
+          <div key={index} className='flex items-center gap-2'>
+            <Span cssOption='h-3 w-3 rounded-full block' style={{ backgroundColor: item.color }} />
+            <Span cssOption='text-gray-500' content={`${item.range} ${item.description}`} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/front/src/component/organism/MainResponse.tsx
+++ b/front/src/component/organism/MainResponse.tsx
@@ -1,7 +1,8 @@
-import { BarChart } from '@chart/BarChart';
+import BarChart from '@chart/BarChart';
 import DataLayout from '@component/template/DataLayout';
-import { CHART_COLORS } from '@constant/ChartColors';
 import useTop5ResponseTime from '@hook/api/useTop5ResponseTime';
+
+import { CHART_COLORS } from '@/constant/Chart';
 
 type Props = {
   generation: string;

--- a/front/src/component/organism/MainTrafficChart.tsx
+++ b/front/src/component/organism/MainTrafficChart.tsx
@@ -1,8 +1,7 @@
-import { LineChart } from '@chart/LineChart';
+import LineChart from '@chart/LineChart';
 import DataLayout from '@component/template/DataLayout';
 import { DAY_TO_MS_SECOND } from '@constant/Time';
 import useTop5Traffic from '@hook/api/useTop5Traffic';
-import { Top5Traffic } from '@type/api';
 import { fillEmptySlots } from '@util/Time';
 import { useMemo } from 'react';
 
@@ -14,18 +13,11 @@ export default function MainTrafficChart({ generation }: Props) {
   const { data } = useTop5Traffic(generation);
 
   const series = useMemo(() => {
-    return data.map((item: Top5Traffic) => ({
-      name: item.name || 'Unknown',
-      data: fillEmptySlots(
-        item.traffic.reduce<Array<[string, string]>>((acc, value, index, arr) => {
-          if (index % 2 === 0 && index + 1 < arr.length) {
-            acc.push([value, arr[index + 1]]);
-          }
-          return acc;
-        }, [])
-      ).map(([timestamp, value]) => ({
+    return data.trafficCharts.map((chart) => ({
+      name: chart.name || 'Unknown',
+      data: fillEmptySlots(chart.traffic).map(([timestamp, value]) => ({
         x: new Date(timestamp),
-        y: value
+        y: Number(value)
       }))
     }));
   }, [data]);

--- a/front/src/component/organism/NavbarSelectWrapper.tsx
+++ b/front/src/component/organism/NavbarSelectWrapper.tsx
@@ -12,7 +12,7 @@ type Props = NavbarSelectProps;
 
 export default function NavbarSelectWrapper(props: Props) {
   const { pathname } = useLocation();
-  const isProjectPath = pathname === PATH.PROJECT;
+  const isProjectPath = pathname.includes(PATH.PROJECT);
   const containerRef = useRef<HTMLDivElement>(null);
   const duckAnimation = useDuckAnimation({ containerRef });
 

--- a/front/src/component/organism/ProjectDAU.tsx
+++ b/front/src/component/organism/ProjectDAU.tsx
@@ -1,0 +1,19 @@
+import DataLayout from '@component/template/DataLayout';
+import useProjectDAU from '@hook/api/useProjectDAU';
+
+type Props = {
+  id: string;
+};
+
+export default function ProjectDAU({ id }: Props) {
+  const { data } = useProjectDAU(id);
+
+  return (
+    <DataLayout cssOption='flex flex-col p-8 rounded-lg shadow-md w-full bg-white'>
+      <div className='mb-8 text-center'>
+        <h2 className='text-navy text-2xl font-bold'>DAU</h2>
+      </div>
+      <div className='h-[220px] w-full'>요기 라이브러리 코드적용</div>
+    </DataLayout>
+  );
+}

--- a/front/src/component/organism/ProjectElapsedTime.tsx
+++ b/front/src/component/organism/ProjectElapsedTime.tsx
@@ -1,0 +1,99 @@
+import PolarAreaChart from '@chart/PolarAreaChart';
+import ProjectElapsedTimeLegend from '@component/molecule/ProjectElapsedTimeLegend';
+import DataLayout from '@component/template/DataLayout';
+import useProjectElapsedTime from '@hook/api/useProjectElapsedTime';
+
+type Props = {
+  id: string;
+};
+
+export default function ProjectElapsedTime({ id }: Props) {
+  const { data } = useProjectElapsedTime(id);
+
+  if (!data?.fastestPaths?.length && !data?.slowestPaths?.length) {
+    return (
+      <DataLayout cssOption='flex flex-col p-8 rounded-lg shadow-md w-full'>
+        <div className='mb-8 text-center'>
+          <h2 className='text-navy text-2xl font-bold'>Response Speed</h2>
+        </div>
+        <div className='text-gray-500 flex w-full flex-1 items-center justify-center text-center'>
+          No response time data available
+        </div>
+      </DataLayout>
+    );
+  }
+
+  const fastestPaths = data.fastestPaths;
+  const slowestPaths = data.slowestPaths;
+  const allPaths = [...fastestPaths, ...slowestPaths];
+  const pathNames = allPaths.map((item) => item.path);
+  const series = allPaths.map((item) => item.avgResponseTime);
+
+  const getAverageResponseTime = () => {
+    return Number(
+      (
+        fastestPaths.reduce((acc, cur) => acc + cur.avgResponseTime, 0) / fastestPaths.length
+      ).toFixed(0)
+    );
+  };
+
+  const getLabelType = (index: number) => {
+    if (index < fastestPaths.length) return 'Fastest';
+    return 'Slowest';
+  };
+
+  const options: ApexCharts.ApexOptions = {
+    colors: [
+      ...Array(fastestPaths.length).fill('#4ADE80'),
+      ...Array(slowestPaths.length).fill('#FF4444')
+    ],
+    labels: pathNames,
+    tooltip: {
+      custom: function ({ seriesIndex }) {
+        const path = pathNames[seriesIndex];
+        const value = series[seriesIndex];
+        const type = getLabelType(seriesIndex);
+        const color = seriesIndex < fastestPaths.length ? '#4ADE80' : '#FF4444';
+
+        return `
+          <div style="
+            padding: 8px;
+            font-size: 12px;
+            background: rgba(0, 0, 0, 0.8);
+            color: #fff;
+            border-radius: 3px;
+          ">
+            <div style="margin-bottom: 4px;">
+              <span style="color: ${color};">● </span>
+              <span style="font-weight: bold;">${type}</span>
+            </div>
+            <div style="margin-bottom: 4px;">${path}</div>
+            <div style="font-weight: bold;">${value.toLocaleString()}ms</div>
+          </div>
+        `;
+      }
+    },
+    stroke: {
+      width: 1,
+      colors: ['#fff']
+    },
+    fill: {
+      opacity: 0.8
+    },
+    legend: {
+      show: false
+    }
+  };
+
+  return (
+    <DataLayout cssOption='flex flex-col p-8 rounded-lg shadow-md w-full'>
+      <div className='mb-8 text-center'>
+        <h2 className='text-navy text-2xl font-bold'>Response Speed</h2>
+      </div>
+      <div className='w-full flex-1'>
+        <PolarAreaChart options={options} series={series} />
+      </div>
+      <ProjectElapsedTimeLegend averageTime={getAverageResponseTime()} />
+    </DataLayout>
+  );
+}

--- a/front/src/component/organism/ProjectSuccessRate.tsx
+++ b/front/src/component/organism/ProjectSuccessRate.tsx
@@ -1,0 +1,71 @@
+import PieChart from '@chart/PieChart';
+import DataLayout from '@component/template/DataLayout';
+import { SUCCESS_FAIL_COLORS } from '@constant/Chart';
+import useProjectSuccessRate from '@hook/api/useProjectSuccessRate';
+
+type Props = {
+  id: string;
+};
+
+export default function ProjectSuccessRate({ id }: Props) {
+  const { data } = useProjectSuccessRate(id);
+
+  const successRate = Number(data.success_rate.toFixed(0));
+  const failRate = Number((100 - data.success_rate).toFixed(0));
+
+  const series = [successRate, failRate];
+
+  const options: ApexCharts.ApexOptions = {
+    colors: SUCCESS_FAIL_COLORS,
+    labels: ['Success %', 'Fail %'],
+    legend: {
+      show: false
+    },
+    plotOptions: {
+      pie: {
+        donut: {
+          labels: {
+            show: true,
+            total: {
+              show: true,
+              label: 'Total Success',
+              color: '#94A3B8',
+              formatter: function () {
+                return successRate.toFixed(0) + '%';
+              }
+            },
+            value: {
+              color: '#94A3B8'
+            }
+          }
+        }
+      }
+    },
+    tooltip: {
+      enabled: true,
+      custom: function ({ seriesIndex }) {
+        const label = seriesIndex === 0 ? 'success_rate' : 'fail_rate';
+        const value = seriesIndex === 0 ? successRate : failRate;
+        return (
+          '<div class="custom-tooltip" style="padding: 8px;">' +
+          '<span style="color: ' +
+          SUCCESS_FAIL_COLORS[seriesIndex] +
+          ';">●</span> ' +
+          `<span style="color: white;">${label}: ${value}%</span>` +
+          '</div>'
+        );
+      }
+    }
+  };
+
+  return (
+    <DataLayout cssOption='flex flex-col p-8 rounded-lg shadow-md w-full'>
+      <div className='mb-8 text-center'>
+        <h2 className='text-navy text-2xl font-bold'>Request Success Rate</h2>
+      </div>
+      <div className='w-full flex-1'>
+        <PieChart options={options} series={series} />
+      </div>
+    </DataLayout>
+  );
+}

--- a/front/src/component/page/ErrorPage.tsx
+++ b/front/src/component/page/ErrorPage.tsx
@@ -1,0 +1,50 @@
+import FaviconImg from '@asset/image/Favicon.svg';
+import Img from '@component/atom/Img';
+import NavigateButton from '@component/molecule/NavigateButton';
+import { motion } from 'framer-motion';
+
+export default function ErrorPage() {
+  const raindrops = Array.from({ length: 30 }, (_, i) => i);
+
+  const getRandomX = () => Math.random() * 300 - 100;
+
+  return (
+    <div className='bg-gray-50 relative flex h-screen w-full items-center justify-center overflow-hidden'>
+      {raindrops.map((i) => (
+        <motion.div
+          key={i}
+          initial={{
+            x: getRandomX(),
+            y: -20,
+            opacity: 1,
+            rotate: 0,
+            scale: Math.random() * 0.5 + 0.8
+          }}
+          animate={{
+            y: '100vh',
+            rotate: 360,
+            opacity: [1, 0.8, 0.6, 0.4, 0.2]
+          }}
+          transition={{
+            duration: Math.random() * 3 + 2,
+            repeat: Infinity,
+            ease: 'linear',
+            delay: Math.random() * 3
+          }}
+          className='absolute top-0 h-6 w-6'>
+          <Img src={FaviconImg} cssOption='w-full h-full' alt='부덕이 이미지' />
+        </motion.div>
+      ))}
+
+      <div className='z-10 flex flex-col gap-4 text-center'>
+        <h1 className='text-6xl font-bold text-yellow-300'>404</h1>
+        <p className='text-xl text-blue'>Page Not Found</p>
+        <NavigateButton
+          path='/'
+          content='Go To Main'
+          cssOption='text-white bg-blue px-8 py-3 rounded-md hover:bg-blue-600 transition-all duration-300 shadow-md hover:shadow-lg font-semibold mt-4 hover:text-black'
+        />
+      </div>
+    </div>
+  );
+}

--- a/front/src/component/page/ErrorPage.tsx
+++ b/front/src/component/page/ErrorPage.tsx
@@ -14,7 +14,7 @@ export default function ErrorPage() {
         <motion.div
           key={i}
           initial={{
-            x: getRandomX(),
+            x: getRandomX() + 'vw',
             y: -20,
             opacity: 1,
             rotate: 0,

--- a/front/src/component/page/MainPage.tsx
+++ b/front/src/component/page/MainPage.tsx
@@ -12,7 +12,7 @@ export default function MainPage() {
   const { generation } = useNavContext<Props>();
 
   return (
-    <div className='bg-lightgray dark:bg-lightblack flex h-screen w-full flex-col gap-8 p-8'>
+    <div className='flex h-screen w-full flex-col gap-8 bg-lightgray p-8 dark:bg-lightblack'>
       <div className='mt-8 grid h-1/2 grid-cols-1 gap-8 lg:grid-cols-2'>
         <CustomErrorBoundary>
           <MainData generation={generation} />

--- a/front/src/component/page/ProjectDetailPage.tsx
+++ b/front/src/component/page/ProjectDetailPage.tsx
@@ -1,0 +1,44 @@
+import CustomErrorBoundary from '@boundary/CustomErrorBoundary';
+import ProjectDAU from '@component/organism/ProjectDAU';
+import ProjectElapsedTime from '@component/organism/ProjectElapsedTime';
+import ProjectSuccessRate from '@component/organism/ProjectSuccessRate';
+import useIsExistGroup from '@hook/api/useIsExistGroup';
+import { Navigate, useParams } from 'react-router-dom';
+
+export default function ProjectDetailPage() {
+  const { id } = useParams();
+
+  if (id === undefined) {
+    return <Navigate to='/404' />;
+  }
+
+  const { data, isLoading } = useIsExistGroup(id);
+  if (isLoading) {
+    return null;
+  }
+  if (data?.exists === false) {
+    return <Navigate to='/404' />;
+  }
+
+  return (
+    <div className='flex h-screen w-full flex-col gap-8 bg-lightgray p-8 dark:bg-lightblack'>
+      <div className='mt-8 grid max-h-[400px] grid-cols-1 gap-8 lg:grid-cols-3'>
+        <CustomErrorBoundary>
+          <ProjectElapsedTime id={id} />
+        </CustomErrorBoundary>
+        <CustomErrorBoundary>
+          <ProjectSuccessRate id={id} />
+        </CustomErrorBoundary>
+        <CustomErrorBoundary>
+          <ProjectDAU id={id} />
+        </CustomErrorBoundary>
+      </div>
+
+      <div className='min-h-0 flex-1'>
+        <CustomErrorBoundary>
+          <div>ProjectDetailPage</div>
+        </CustomErrorBoundary>
+      </div>
+    </div>
+  );
+}

--- a/front/src/component/page/ProjectDetailPage.tsx
+++ b/front/src/component/page/ProjectDetailPage.tsx
@@ -14,7 +14,7 @@ export default function ProjectDetailPage() {
 
   const { data, isLoading } = useIsExistGroup(id);
   if (isLoading) {
-    return null;
+    return;
   }
   if (data?.exists === false) {
     return <Navigate to='/404' />;

--- a/front/src/component/page/ProjectPage.tsx
+++ b/front/src/component/page/ProjectPage.tsx
@@ -1,3 +1,16 @@
+import Loading from '@component/atom/Loading';
+import useGroupNames from '@hook/api/useGroupNames';
+import { Navigate } from 'react-router-dom';
+
 export default function ProjectPage() {
-  return <div className='flex h-screen w-full bg-gray-50'>개별페이지입니다</div>;
+  const { data, isLoading } = useGroupNames('9');
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  if (!data?.length) {
+    return <Navigate to='/404' />;
+  }
+
+  return <Navigate to={`/project/${data[0].value}`} />;
 }

--- a/front/src/constant/Chart.ts
+++ b/front/src/constant/Chart.ts
@@ -1,0 +1,11 @@
+const CHART_COLORS = ['#FF6B6B', '#FF9F43', '#FECA57', '#4ECB71', '#4B7BEC'];
+const SUCCESS_FAIL_COLORS = ['#4ADE80', '#FF4444'];
+const POLAR_AREA_COLORS = ['#FF6B6B', '#FF9F43', '#FECA57', '#4ECB71', '#4B7BEC', '#4ADE80'];
+
+const RESPONSE_TIME_LEGENDS = [
+  { color: '#4ADE80', range: '0 ~ 200', description: 'great' },
+  { color: '#FFA500', range: '201 ~ 1000', description: 'good' },
+  { color: '#FF4444', range: '1001 ~', description: 'bad' }
+];
+
+export { CHART_COLORS, RESPONSE_TIME_LEGENDS, SUCCESS_FAIL_COLORS, POLAR_AREA_COLORS };

--- a/front/src/constant/ChartColors.ts
+++ b/front/src/constant/ChartColors.ts
@@ -1,3 +1,0 @@
-const CHART_COLORS = ['#FF6B6B', '#FF9F43', '#FECA57', '#4ECB71', '#4B7BEC'];
-
-export { CHART_COLORS };

--- a/front/src/hook/api/useGroupNames.ts
+++ b/front/src/hook/api/useGroupNames.ts
@@ -1,9 +1,9 @@
 import { getGroupNames } from '@api/get';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 
 export default function useGroupNames(generation: string) {
-  return useSuspenseQuery({
+  return useQuery({
     queryKey: ['groupNames', generation],
-    queryFn: () => getGroupNames(generation)
+    queryFn: () => getGroupNames(generation),
   });
 }

--- a/front/src/hook/api/useIsExistGroup.ts
+++ b/front/src/hook/api/useIsExistGroup.ts
@@ -1,0 +1,9 @@
+import { getIsExistProject } from '@api/get';
+import { useQuery } from '@tanstack/react-query';
+
+export default function useIsExistGroup(project: string) {
+  return useQuery({
+    queryKey: ['isExistProject', project],
+    queryFn: () => getIsExistProject(project)
+  });
+}

--- a/front/src/hook/api/useProjectDAU.ts
+++ b/front/src/hook/api/useProjectDAU.ts
@@ -1,0 +1,9 @@
+import { getDAU } from '@api/get';
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+export default function useProjectDAU(project: string) {
+  return useSuspenseQuery({
+    queryKey: ['projectDAU', project],
+    queryFn: () => getDAU(project)
+  });
+}

--- a/front/src/hook/api/useProjectElapsedTime.ts
+++ b/front/src/hook/api/useProjectElapsedTime.ts
@@ -1,0 +1,9 @@
+import { getElapsedTime } from '@api/get';
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+export default function useProjectElapsedTime(project: string) {
+  return useSuspenseQuery({
+    queryKey: ['projectElapsedTime', project],
+    queryFn: () => getElapsedTime(project)
+  });
+}

--- a/front/src/hook/api/useProjectSuccessRate.ts
+++ b/front/src/hook/api/useProjectSuccessRate.ts
@@ -1,0 +1,9 @@
+import { getSuccessRate } from '@api/get';
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+export default function useProjectSuccessRate(project: string) {
+  return useSuspenseQuery({
+    queryKey: ['projectSuccessRate', project],
+    queryFn: () => getSuccessRate(project)
+  });
+}

--- a/front/src/hook/api/useRankings.ts
+++ b/front/src/hook/api/useRankings.ts
@@ -1,9 +1,8 @@
 import { getRankings } from '@api/get';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { Ranking } from '@type/api';
 
 export default function useRankings(generation: string) {
-  return useSuspenseQuery<Ranking[]>({
+  return useSuspenseQuery({
     queryKey: ['ranking', generation],
     queryFn: () => getRankings(generation)
   });

--- a/front/src/hook/api/useTop5ResponseTime.ts
+++ b/front/src/hook/api/useTop5ResponseTime.ts
@@ -1,9 +1,8 @@
 import { getTop5ResponseTime } from '@api/get';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { ResponseTime } from '@type/api';
 
 export default function useTop5ResponseTime(generation: string) {
-  return useSuspenseQuery<ResponseTime[]>({
+  return useSuspenseQuery({
     queryKey: ['Top5ResponseTime', generation],
     queryFn: () => getTop5ResponseTime(generation)
   });

--- a/front/src/hook/api/useTop5Traffic.ts
+++ b/front/src/hook/api/useTop5Traffic.ts
@@ -1,9 +1,8 @@
 import { getTop5Traffic } from '@api/get';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { Top5Traffic } from '@type/api';
 
 export default function useTop5Traffic(generation: string) {
-  return useSuspenseQuery<Top5Traffic[]>({
+  return useSuspenseQuery({
     queryKey: ['Top5Traffic', generation],
     queryFn: () => getTop5Traffic(generation)
   });

--- a/front/src/hook/api/useTotalDatas.ts
+++ b/front/src/hook/api/useTotalDatas.ts
@@ -1,5 +1,5 @@
 import {
-  getTotalTraffic,
+  getTotalTrafficCount,
   getTotalProjectCount,
   getTotalResponseRate,
   getDailyDifferenceTraffic,
@@ -10,7 +10,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 export default function useTotalDatas(generation: string) {
   const { data: trafficData } = useSuspenseQuery({
     queryKey: ['totalTraffic', generation],
-    queryFn: () => getTotalTraffic(generation)
+    queryFn: () => getTotalTrafficCount(generation)
   });
 
   const { data: projectData } = useSuspenseQuery({

--- a/front/src/type/api.ts
+++ b/front/src/type/api.ts
@@ -25,8 +25,40 @@ type ResponseTime = {
 };
 
 type Top5Traffic = {
-  name: string;
-  traffic: string[];
+  trafficCharts: {
+    name: string;
+    traffic: [string, string][];
+  }[];
+};
+
+type ProjectElapsedTime = {
+  projectName: string;
+  fastestPaths: { path: string; avgResponseTime: number }[];
+  slowestPaths: { path: string; avgResponseTime: number }[];
+};
+
+type ProjectSuccessRate = {
+  projectName: string;
+  success_rate: number;
+};
+
+type ProjectDAU = {
+  projectName: string;
+  dauRecords: [{ date: string; dau: number }];
+};
+
+type ProjectTraffic = {
+  projectName: string;
+  trafficData: [
+    {
+      timestamp: string;
+      count: number;
+    }
+  ];
+};
+
+type ProjectExist = {
+  exists: boolean;
 };
 
 export type {
@@ -36,5 +68,10 @@ export type {
   DailyDifferenceTraffic,
   ElapsedTime,
   ResponseTime,
-  Top5Traffic
+  Top5Traffic,
+  ProjectSuccessRate,
+  ProjectDAU,
+  ProjectTraffic,
+  ProjectElapsedTime,
+  ProjectExist
 };

--- a/front/src/util/Time.ts
+++ b/front/src/util/Time.ts
@@ -10,7 +10,6 @@ const generateTimeSlots = () => {
     const timestamp = new Date(startDate);
     timestamp.setMinutes(i * 10);
     const formattedTime = `${timestamp.getFullYear()}-${String(timestamp.getMonth() + 1).padStart(2, '0')}-${String(timestamp.getDate()).padStart(2, '0')} ${String(timestamp.getHours()).padStart(2, '0')}:${String(timestamp.getMinutes()).padStart(2, '0')}:00`;
-
     result.push([formattedTime, 0]);
   }
   return result;
@@ -21,6 +20,5 @@ const fillEmptySlots = (rawData: Array<[string, string]>) => {
   const dataMap = new Map(rawData.map(([timestamp, value]) => [timestamp, Number(value)]));
   return timeSlots.map(([timestamp]) => [timestamp, dataMap.get(timestamp) || 0]);
 };
-
 
 export { fillEmptySlots };


### PR DESCRIPTION
### 👀 관련 이슈
#161 
#165

### ✨ 작업한 내용

- [x] 개별페이지 응답성공률 파이차트 구현
- [x] 개별페이지 top3속도 차트 구현
- [x] 에러페이지 구현
- [x] top5랭킹을 누르면 해당 프로젝트의 개별페이지로 이동
- [x] 새로고침 시, NavbarSelect의 상태가 초기화되던 버그 수정  

### 🌀 PR Point

차트를 구현하는 과정에서 불필요한 options들을 만들게 됐는데..
상수분리를 좀 고민했습니다.
코드맥락상 다른 파일로 분리하면 오히려 읽기 힘들 것 같아, 컴포넌트 내의 상수로 두었습니다.
그외엔 짜잘한 버그를 수정한거라서, 리뷰하는데 어렵지 않을 것 같네요!

### 📷 스크린샷 또는 GIF

개별프로젝트 페이지
<img width="1140" alt="image" src="https://github.com/user-attachments/assets/aa4990a8-de12-4210-baad-15961fa867ec">

에러페이지

https://github.com/user-attachments/assets/70303c42-2dec-4c26-b244-cfd52bad0721


