### PR TITLE
[BE] DAU 구현 방식 변경

### DIFF
--- a/backend/console-server/src/log/analytics/analytics.repository.ts
+++ b/backend/console-server/src/log/analytics/analytics.repository.ts
@@ -6,12 +6,14 @@ import { DauMetric } from './metric/dau.metric';
 @Injectable()
 export class AnalyticsRepository {
     constructor(private readonly clickhouse: Clickhouse) {}
-
     async findDAUsByProject(domain: string, start: Date, end: Date) {
         const { query, params } = new TimeSeriesQueryBuilder()
-            .metrics([{ name: `date` }, { name: `SUM(access) as dau` }])
-            .from('dau')
-            .filter({ domain })
+            .metrics([
+                { name: `toDate(timestamp) as date` },
+                { name: `count(DISTINCT user_ip) as dau` },
+            ])
+            .from('http_log')
+            .filter({ host: domain })
             .timeBetween(start, end, 'date')
             .groupBy(['date'])
             .orderBy(['date'])

--- a/backend/console-server/src/log/rank/rank.controller.ts
+++ b/backend/console-server/src/log/rank/rank.controller.ts
@@ -54,7 +54,7 @@ export class RankController {
     })
     @ApiResponse({
         status: HttpStatus.OK,
-        description: '기수 내 DAU 랭킹이 송공적으로 반환됨.',
+        description: '기수 내 DAU 랭킹이 성공적으로 반환됨.',
         type: GetDAURankResponseDto,
     })
     async getDAURank(@Query() getDAURankDto: GetDAURankDto) {

--- a/backend/console-server/src/log/rank/rank.repository.spec.ts
+++ b/backend/console-server/src/log/rank/rank.repository.spec.ts
@@ -163,8 +163,8 @@ describe('RankRepository', () => {
     describe('findDAUOrderByCount()는', () => {
         const testDate = '2024-11-25';
         const mockQueryResult = {
-            query: 'SELECT domain as host, SUM(access) as dau FROM dau WHERE date = {date} GROUP BY domain ORDER BY dau DESC',
-            params: { date: testDate },
+            query: 'SELECT host, count(DISTINCT user_ip) as dau FROM http_log GROUP BY host, timestamp ORDER BY dau DESC',
+            params: { timestamp: testDate },
         };
 
         const mockResults = [
@@ -192,12 +192,13 @@ describe('RankRepository', () => {
             const queryBuilder = (TimeSeriesQueryBuilder as jest.Mock).mock.results[0].value;
 
             expect(queryBuilder.metrics).toHaveBeenCalledWith([
-                { name: 'domain as host' },
-                { name: 'SUM(access) as dau' },
+                { name: 'host' },
+                { name: 'count(DISTINCT user_ip) as dau' },
+                { name: 'toDate(timestamp) as timestamp' },
             ]);
-            expect(queryBuilder.from).toHaveBeenCalledWith('dau');
-            expect(queryBuilder.filter).toHaveBeenCalledWith({ date: testDate });
-            expect(queryBuilder.groupBy).toHaveBeenCalledWith(['domain']);
+            expect(queryBuilder.from).toHaveBeenCalledWith('http_log');
+            expect(queryBuilder.filter).toHaveBeenCalledWith({ timestamp: testDate });
+            expect(queryBuilder.groupBy).toHaveBeenCalledWith(['host', 'timestamp']);
             expect(queryBuilder.orderBy).toHaveBeenCalledWith(['dau'], true);
         });
 

--- a/backend/console-server/src/log/rank/rank.repository.ts
+++ b/backend/console-server/src/log/rank/rank.repository.ts
@@ -49,10 +49,6 @@ export class RankRepository {
             .orderBy(['dau'], true)
             .build();
 
-        console.log('=== ClickHouse Query ===');
-        console.log('Query:', query);
-        console.log('Params:', params);
-
         return await this.clickhouse.query<HostDauMetric>(query, params);
     }
 

--- a/backend/console-server/src/log/rank/rank.repository.ts
+++ b/backend/console-server/src/log/rank/rank.repository.ts
@@ -38,12 +38,20 @@ export class RankRepository {
 
     async findCountOrderByDAU(date: string) {
         const { query, params } = new TimeSeriesQueryBuilder()
-            .metrics([{ name: 'domain as host' }, { name: 'SUM(access) as dau' }])
-            .from('dau')
-            .filter({ date })
-            .groupBy(['domain'])
+            .metrics([
+                { name: 'host' },
+                { name: 'count(DISTINCT user_ip) as dau' },
+                { name: 'toDate(timestamp) as timestamp' },
+            ])
+            .from('http_log')
+            .filter({ timestamp: date })
+            .groupBy(['host', 'timestamp'])
             .orderBy(['dau'], true)
             .build();
+
+        console.log('=== ClickHouse Query ===');
+        console.log('Query:', query);
+        console.log('Params:', params);
 
         return await this.clickhouse.query<HostDauMetric>(query, params);
     }


### PR DESCRIPTION
### 👀 관련 이슈
#230 

### ✨ 작업한 내용
- 랭킹페이지 dau api 변경
- 개별 프로젝트 dau api 변경

- http_log 테이블에서 distinct(user_ip) 해오는 방식으로 구현하였습니다.

### 🌀 PR Point

- 제가 대...삽질을 했는데요,,, 아직도 원인은 모르겠지만, mysql db와 clickhouse db 연동이 잘 안되는 것 같습니다... 그래서 저한테는 아래 결과처럼 모든 프로젝트가 unknown이라고 뜨는데요...! 이건 제 api 뿐만 아니라, 모든 api(잘 작동하고 있는...)에서도 저렇게 뜨더라구요 ㅠ
그래서 혹시나 api에 잘못된 부분이 있어보인다면 말씀해주세요 ㅠㅠ (아마 repository만 건드려서 mapping 하는데 문제는 없을 것 같지만요...)
- 그리고 날짜가 잘못 잡히는지 이상한 날짜의 것을 가져와서 계속 빈 배열로 오더니... 날짜가 딱 바뀌니까(12시가) 결과값이 나타나더라구요...? 제 로컬 디비들의 문제들 같긴 합니다 ㅠㅠ 왜 갑자기 이상해졌는진 모르겠네요 ㅠ

**=> 오마이갓... 로컬 캐시 때문이었어요 ㅠㅠㅠㅠㅠㅠㅠ 레디스 캐시 없애주니까 잘되네요 ...ㅎ 근데 console.log는 왜 안되는건지 ㅠㅠ**

- 그래서 sql을 직접 찍어보거나 서비스 계층에서 문제가 있는지 확인 같은걸 하고 싶었는데,,, 저만 console.log()가 안되나요...? 이걸로 확인할 수가 없어서 디버깅 도구를 이용했는데, 문제는 없어보였는데 확신할 수가 없었어서 오래 걸렸네요 ㅠ 아무리 만져봐도 console.log 자체가 안되는데 무슨 설정같은 걸 걸어두신 분 있나요...? 그렇다기엔 dev 환경에서도 안되긴 해서 ㅠㅠ 이것 때문에 시간 쓰다가 결국 해결은 못했네요 ㅠ


### 🍰 참고사항


### 📷 스크린샷 또는 GIF
![image](https://github.com/user-attachments/assets/cf09c92d-4197-49c7-86f5-09b39d33bd23)
