### PR TITLE
[FE] 반응형 설정 추가

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,15 @@
+import MobileLayout from '@component/template/MobileLayout';
+import useIsMobile from '@hook/useIsMobile';
 import router from '@router/Router';
 import { RouterProvider } from 'react-router-dom';
 
 export default function App() {
-  return <RouterProvider router={router} />;
+  const isMobile = useIsMobile();
+
+  return (
+    <>
+      {isMobile && <MobileLayout />}
+      <RouterProvider router={router} />
+    </>
+  );
 }

--- a/frontend/src/boundary/CustomErrorBoundary.tsx
+++ b/frontend/src/boundary/CustomErrorBoundary.tsx
@@ -1,9 +1,8 @@
+import CustomErrorFallback from '@boundary/CustomErrorFallback';
 import Loading from '@component/atom/Loading';
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
 import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
-
-import CustomErrorFallback from './CustomErrorFallback';
 
 type Props = {
   children: React.ReactNode;

--- a/frontend/src/chart/PolarAreaChart.tsx
+++ b/frontend/src/chart/PolarAreaChart.tsx
@@ -11,7 +11,10 @@ export default function PolarAreaChart({ series, options: additionalOptions }: P
   const PolarChartOption: ApexCharts.ApexOptions = {
     chart: {
       type: 'polarArea',
-      height: 300
+      height: '100%',
+      width: '100%',
+      redrawOnParentResize: true,
+      redrawOnWindowResize: true
     },
     plotOptions: {
       polarArea: {

--- a/frontend/src/component/atom/Loading.tsx
+++ b/frontend/src/component/atom/Loading.tsx
@@ -2,8 +2,8 @@ export default function Loading() {
   return (
     <div className='flex items-center justify-center gap-4 bg-opacity-75 p-4 text-center'>
       <div className='relative inline-flex'>
-        <div className='absolute h-12 w-12 rounded-full border-1.5 border-gray' />
-        <div className='h-24 w-24 animate-spin rounded-31 border-1.5 border-solid border-gray/30 border-t-gray [animation-duration:1.5s]' />
+        <div className='absolute h-[12px] w-[12px] rounded-full border-[1.5px] border-gray' />
+        <div className='h-[24px] w-[24px] animate-spin rounded-[31px] border-[1.5px] border-solid border-gray/30 border-t-gray [animation-duration:1.5s]' />
       </div>
       <span className='text-lg font-medium text-gray'>Loading...</span>
     </div>

--- a/frontend/src/component/molecule/NavbarContact.tsx
+++ b/frontend/src/component/molecule/NavbarContact.tsx
@@ -6,12 +6,12 @@ import { Link } from 'react-router-dom';
 
 export default function NavbarContact() {
   return (
-    <div className='flex items-center gap-2'>
+    <div className='flex w-[100%] items-center gap-2'>
       <Link to={PATH.GITHUB} target='_blank' className='flex-shrink-0'>
-        <Img src={GithubImg} alt='깃허브 이미지' cssOption='w-24 h-24 dark:invert' />
+        <Img src={GithubImg} alt='깃허브 이미지' cssOption='w-[24px] h-[24px] dark:invert' />
       </Link>
       <P
-        cssOption='text-10 flex items-center whitespace-nowrap text-gray'
+        cssOption='text-[0.6vw] flex items-center whitespace-nowrap truncate text-gray'
         content='Contact us : shson1217@naver.com'
       />
     </div>

--- a/frontend/src/component/molecule/NavbarMenu.tsx
+++ b/frontend/src/component/molecule/NavbarMenu.tsx
@@ -12,7 +12,7 @@ export default function NavbarMenu() {
     return (
       <Link to={item.path}>
         <div
-          className={`flex cursor-pointer items-center gap-4 md:gap-8 ${
+          className={`flex cursor-pointer items-center gap-4 md:gap-[8px] ${
             isActive
               ? 'dark:text-white dark:hover:text-white'
               : 'text-gray hover:text-black dark:hover:text-white'
@@ -22,15 +22,18 @@ export default function NavbarMenu() {
             alt={`${item.label} 아이콘`}
             cssOption='w-4 md:w-6'
           />
-          <P content={item.label} cssOption='text-12 md:text-14 whitespace-nowrap' />
+          <P content={item.label} cssOption='text-[1vw] trunacte' />
         </div>
       </Link>
     );
   }
 
   return (
-    <div className='flex flex-col gap-8 md:gap-16'>
-      <H1 cssOption='mt-8 text-14 md:text-16 whitespace-nowrap dark:text-white' content='MENU' />
+    <div className='flex flex-col gap-[8px] md:gap-[16px]'>
+      <H1
+        cssOption='mt-[8px] text-[14px] md:text-16 whitespace-nowrap dark:text-white'
+        content='MENU'
+      />
       {MENU_ITEMS.map((item) => (
         <MenuItem
           key={item.path}

--- a/frontend/src/component/molecule/NavbarRanking.tsx
+++ b/frontend/src/component/molecule/NavbarRanking.tsx
@@ -61,8 +61,8 @@ export default function NavbarRanking() {
   };
 
   return (
-    <div className='mt-8 rounded-10 border-1.5 border-solid border-gray p-4'>
-      <P cssOption='text-12 mb-1 font-bold dark:text-white' content='TRAFFIC RANKING' />
+    <div className='mt-[8px] rounded-[10px] border-[1.5px] border-solid border-gray p-4'>
+      <P cssOption='text-[0.9vw] mb-1 font-bold dark:text-white' content='TRAFFIC RANKING' />
       {data.rank.map((item, index) => renderRankingItem(item, index))}
     </div>
   );

--- a/frontend/src/component/molecule/NavbarSelect.tsx
+++ b/frontend/src/component/molecule/NavbarSelect.tsx
@@ -19,17 +19,17 @@ export default function NavbarSelect({ groupOption }: Props) {
   };
 
   return (
-    <div className='flex w-full min-w-0 items-center justify-between rounded-1.5 border-1.5 border-solid border-gray p-4 md:gap-[4px] md:p-8'>
+    <div className='flex w-full min-w-0 items-center justify-between rounded-[1.5px] border-[1.5px] border-solid border-gray p-4 md:gap-[4px] md:p-[8px]'>
       {isProjectPath && (
         <Select
-          cssOption='text-12 md:text-14 md:px-2 text-ellipsis cursor-pointer hover:font-semibold truncate dark:text-white'
+          cssOption='text-[12px] md:text-[14px] md:px-2 text-ellipsis cursor-pointer hover:font-semibold truncate dark:text-white'
           options={GENERATION_OPTION}
           value={generation}
           onChange={setGeneration}
         />
       )}
       <Select
-        cssOption='text-12 md:text-14 md:px-2 text-ellipsis cursor-pointer text-gray hover:font-semibold truncate flex-1'
+        cssOption='text-[12px] md:text-[14px] md:px-2 text-ellipsis cursor-pointer text-gray hover:font-semibold truncate flex-1'
         options={groupOption}
         value={selectedGroup}
         onChange={handleSelect}

--- a/frontend/src/component/molecule/NavbarTitle.tsx
+++ b/frontend/src/component/molecule/NavbarTitle.tsx
@@ -1,5 +1,6 @@
+import FaviconImg from '@asset/image/Favicon.svg';
 import H1 from '@component/atom/H1';
-import P from '@component/atom/P';
+import Img from '@component/atom/Img';
 import { useNavigate } from 'react-router-dom';
 
 export default function NavbarTitle() {
@@ -14,11 +15,8 @@ export default function NavbarTitle() {
       <div
         className='flex min-w-0 cursor-pointer items-center gap-2 md:gap-4'
         onClick={navigateMain}>
-        <P cssOption='text-16 md:text-20 lg:text-24 shrink-0' content='🐥' />
-        <H1
-          cssOption='font-bold text-16 md:text-20 lg:text-24 truncate dark:text-white'
-          content='WatchDucks'
-        />
+        <Img src={FaviconImg} cssOption='w-[36px]' alt='와치덕스 로고 이미지' />
+        <H1 cssOption='font-bold text-[1.6vw] truncate dark:text-white' content='WatchDucks' />
       </div>
     </div>
   );

--- a/frontend/src/component/molecule/ProjectElapsedTimeLegend.tsx
+++ b/frontend/src/component/molecule/ProjectElapsedTimeLegend.tsx
@@ -16,8 +16,8 @@ export default function ProjectElapsedTimeLegend({ averageTime }: Props) {
   return (
     <div className='flex flex-col items-center gap-4'>
       <div className='text-center'>
-        <H2 cssOption='text-navy mb-4 text-xl font-bold' content='TOP3 Average Response Speed' />
-        <div className='mb-4 text-2xl font-bold' style={{ color: getColorByTime(averageTime) }}>
+        <H2 cssOption='text-navy mb-4 text-[1vw] font-bold' content='TOP3 Average Response Speed' />
+        <div className='mb-4 text-[2vw] font-bold' style={{ color: getColorByTime(averageTime) }}>
           {averageTime || 0}ms
         </div>
       </div>

--- a/frontend/src/component/molecule/RankingItem.tsx
+++ b/frontend/src/component/molecule/RankingItem.tsx
@@ -27,7 +27,7 @@ export default function RankingItem({ data }: Props) {
 
     return absoluteIndex <= 2 ? (
       <div
-        className='flex w-full justify-between rounded-[4px] bg-[#3692EF]/[0.2] p-8 text-black dark:text-white'
+        className='flex w-full justify-between rounded-[4px] bg-[#3692EF]/[0.2] p-[8px] text-black dark:text-white'
         key={item.projectName}>
         <div className='flex items-center gap-4'>
           <div className='flex gap-4'>
@@ -45,12 +45,12 @@ export default function RankingItem({ data }: Props) {
         />
         <P
           content={item.value.toString()}
-          cssOption='w-[140px] mr-16 text-right text-[clamp(12px,1.5vw,14px)]'
+          cssOption='w-[140px] mr-[16px]16 text-right text-[clamp(12px,1.5vw,14px)]'
         />
       </div>
     ) : (
       <div
-        className='flex w-full justify-between rounded-[4px] bg-[#3692EF]/[0.2] p-8 text-black dark:text-white'
+        className='flex w-full justify-between rounded-[4px] bg-[#3692EF]/[0.2] p-[8px] text-black dark:text-white'
         key={item.projectName}>
         <div className='flex items-center gap-4'>
           <div className='flex gap-4'>
@@ -65,7 +65,7 @@ export default function RankingItem({ data }: Props) {
         />
         <P
           content={item.value.toString()}
-          cssOption='w-[140px] mr-16 text-right text-[clamp(12px,1.5vw,14px)]'
+          cssOption='w-[140px] mr-[16px]16 text-right text-[clamp(12px,1.5vw,14px)]'
         />
       </div>
     );
@@ -75,13 +75,13 @@ export default function RankingItem({ data }: Props) {
     <button
       key={pageNum}
       onClick={() => setCurrentPage(pageNum)}
-      className={`flex h-8 w-8 items-center justify-center rounded ${currentPage === pageNum ? 'text-dark dark:white' : 'text-gray hover:text-black dark:hover:text-white'} `}>
+      className={`flex h-[8px] w-[8px] items-center justify-center rounded ${currentPage === pageNum ? 'text-dark dark:white' : 'text-gray hover:text-black dark:hover:text-white'} `}>
       {pageNum}
     </button>
   );
 
   return (
-    <div className='flex w-full flex-col gap-8'>
+    <div className='flex w-full flex-col gap-[8px]'>
       {getPageItems().map((item, index) => renderRankingItem(item, index))}
 
       <div className='mt-4 flex items-center justify-center gap-2'>

--- a/frontend/src/component/molecule/RegisterText.tsx
+++ b/frontend/src/component/molecule/RegisterText.tsx
@@ -6,14 +6,14 @@ import P from '@component/atom/P';
 
 export default function RegisterText() {
   return (
-    <div className='flex flex-col gap-10 text-18'>
-      <H1 cssOption='font-medium text-50 border-2' content='등록 절차' />
+    <div className='flex flex-col gap-[10px] text-[18px]'>
+      <H1 cssOption='font-medium text-[50px] border-[2px]' content='등록 절차' />
       <P content='1. 프로젝트명, 도메인, 아이피 주소를 입력합니다.' />
       <P content='2. 등록 완료 후 표시된 네임 서버를 복사합니다.' />
       <P content='3. 상용 DNS (ex. Cloudflare, Gabia)의 가이드에 따라 네임 서버와 IP를 등록해 주세요.' />
-      <P cssOption='mt-20 font-light' content='Gabia 예시' />
+      <P cssOption='mt-[20px] font-light' content='Gabia 예시' />
       <Img cssOption='bg-cover' src={GabiaDescriptionImg} alt='가비아 dns 등록 설명 이미지' />
-      <P cssOption='mt-20 font-light' content='CloudFlare 예시' />
+      <P cssOption='mt-[20px] font-light' content='CloudFlare 예시' />
       <Img
         cssOption='bg-cover'
         src={CloudFlareDescriptionImg}

--- a/frontend/src/component/molecule/ValidateTextInput.tsx
+++ b/frontend/src/component/molecule/ValidateTextInput.tsx
@@ -24,9 +24,9 @@ export default forwardRef<HTMLInputElement, Props>(function ValidateTextInput(
         placeholder={placeholder}
         value={value}
         onChange={onChange}
-        cssOption={`w-full h-40 pl-16 pr-30 border-1.5 rounded-1.5 hover:border-blue ${validationStyle}`}
+        cssOption={`w-full h-[40px] pl-[16px] pr-[30px] border-[1.5px] rounded-[1.5px] hover:border-blue ${validationStyle}`}
       />
-      <div className='absolute right-10 top-1/2 -translate-y-1/2'>
+      <div className='absolute right-[10px] top-1/2 -translate-y-1/2'>
         <ValidIcon type={isValid ? 'success' : 'fail'} />
       </div>
     </div>

--- a/frontend/src/component/organism/MainData.tsx
+++ b/frontend/src/component/organism/MainData.tsx
@@ -22,16 +22,16 @@ export default function MainData({ generation }: Props) {
     : { symbol: '▼', color: 'text-red' };
 
   return (
-    <DataLayout cssOption='p-8 rounded-lg shadow-md w-full justify-center flex-col flex'>
-      <h2 className='text-navy mb-8 text-center text-2xl font-bold'>9기 Total Data</h2>
+    <DataLayout cssOption='p-[8px] rounded-lg shadow-md w-full justify-center flex-col flex'>
+      <h2 className='text-navy mb-[8px] text-center text-2xl font-bold'>9기 Total Data</h2>
 
-      <div className='mt-4 grid grid-cols-2 place-items-center gap-10'>
+      <div className='mt-4 grid grid-cols-2 place-items-center gap-[10px]'>
         <div className='flex flex-col items-center text-center'>
           <TextMotionDiv
             content={`${totalProjectCount}개`}
             cssOption='text-navy text-2xl font-bold'
           />
-          <p className='mt-2 text-sm text-gray-500'>등록된 프로젝트 수</p>
+          <p className='text-gray-500 mt-2 text-sm'>등록된 프로젝트 수</p>
         </div>
 
         <div className='flex flex-col items-center text-center'>
@@ -39,7 +39,7 @@ export default function MainData({ generation }: Props) {
             content={`${(totalTraffic / 1000000).toFixed(1)}M`}
             cssOption='text-navy text-2xl font-bold'
           />
-          <p className='mt-2 text-sm text-gray-500'>총 트래픽</p>
+          <p className='text-gray-500 mt-2 text-sm'>총 트래픽</p>
         </div>
 
         <div className='flex flex-col items-center text-center'>
@@ -47,7 +47,7 @@ export default function MainData({ generation }: Props) {
             content={elapsedTime?.toFixed(0) + 'ms'}
             cssOption='text-navy text-2xl font-bold'
           />
-          <p className='mt-2 text-sm text-gray-500'>평균 응답시간</p>
+          <p className='text-gray-500 mt-2 text-sm'>평균 응답시간</p>
         </div>
 
         <div className='flex flex-col items-center text-center'>
@@ -55,7 +55,7 @@ export default function MainData({ generation }: Props) {
             content={`+${Math.trunc(totalResponseRate)}%`}
             cssOption='text-navy text-2xl font-bold'
           />
-          <p className='mt-2 text-sm text-gray-500'>트래픽 응답 성공률</p>
+          <p className='text-gray-500 mt-2 text-sm'>트래픽 응답 성공률</p>
         </div>
       </div>
 

--- a/frontend/src/component/organism/MainResponse.tsx
+++ b/frontend/src/component/organism/MainResponse.tsx
@@ -55,8 +55,8 @@ export default function MainResponse({ generation }: Props) {
   };
 
   return (
-    <DataLayout cssOption='flex flex-col p-8 rounded-lg shadow-md w-full'>
-      <div className='mb-8 text-center'>
+    <DataLayout cssOption='flex flex-col p-[8px] rounded-lg shadow-md w-full'>
+      <div className='mb-[8px] text-center'>
         <h2 className='text-navy text-2xl font-bold'>TOP5 Response Speed</h2>
       </div>
       <div className='w-full flex-1'>

--- a/frontend/src/component/organism/MainTrafficChart.tsx
+++ b/frontend/src/component/organism/MainTrafficChart.tsx
@@ -72,7 +72,8 @@ export default function MainTrafficChart({ generation }: Props) {
       title: {
         text: 'Traffic Count',
         style: {
-          color: '#64748B'
+          color: '#64748B',
+          fontSize: '12px'
         }
       },
       min: 0
@@ -80,8 +81,8 @@ export default function MainTrafficChart({ generation }: Props) {
   };
 
   return (
-    <DataLayout cssOption='flex flex-col p-8 rounded-lg shadow-md w-full h-full'>
-      <div className='m-16'>
+    <DataLayout cssOption='flex flex-col p-[8px] rounded-lg shadow-md w-full h-full'>
+      <div className='m-[16px]'>
         <h2 className='text-navy text-center text-2xl font-bold'>TOP5 DAILY TRAFFIC</h2>
       </div>
       <div className='w-full flex-1'>

--- a/frontend/src/component/organism/MainTrafficChart.tsx
+++ b/frontend/src/component/organism/MainTrafficChart.tsx
@@ -3,7 +3,6 @@ import DataLayout from '@component/template/DataLayout';
 import { DAY_TO_MS_SECOND } from '@constant/Date';
 import useTop5Traffic from '@hook/api/useTop5Traffic';
 import { fillEmptySlots } from '@util/Time';
-import { useMemo } from 'react';
 
 type Props = {
   generation: string;
@@ -12,15 +11,13 @@ type Props = {
 export default function MainTrafficChart({ generation }: Props) {
   const { data } = useTop5Traffic(generation);
 
-  const series = useMemo(() => {
-    return data.trafficCharts.map((chart) => ({
-      name: chart.name || 'Unknown',
-      data: fillEmptySlots(chart.traffic).map(([timestamp, value]) => ({
-        x: new Date(timestamp),
-        y: Number(value)
-      }))
-    }));
-  }, [data]);
+  const series = data.trafficCharts.map((chart) => ({
+    name: chart.name || 'Unknown',
+    data: fillEmptySlots(chart.traffic).map(([timestamp, value]) => ({
+      x: new Date(timestamp),
+      y: Number(value)
+    }))
+  }));
 
   const options: ApexCharts.ApexOptions = {
     chart: {

--- a/frontend/src/component/organism/NavBar.tsx
+++ b/frontend/src/component/organism/NavBar.tsx
@@ -8,8 +8,8 @@ import NavbarSelectWrapper from '@component/organism/NavbarSelectWrapper';
 
 export default function Navbar() {
   return (
-    <aside className='flex h-screen flex-col bg-lightblue px-24 dark:bg-darkblue'>
-      <div className='flex flex-col gap-16 pt-24'>
+    <aside className='border-3 flex h-screen flex-col rounded-[11px] bg-lightblue p-[24px] dark:bg-darkblue'>
+      <div className='flex flex-col gap-[16px] pt-[24px]'>
         <NavbarTitle />
         <NavbarSelectWrapper />
         <NavbarMenu />
@@ -19,10 +19,10 @@ export default function Navbar() {
         <NavigateButton
           path='/register'
           content='프로젝트 등록하러가기'
-          cssOption='flex items-center mt-24 whitespace-nowrap rounded-10 bg-blue p-16 text-10 text-white hover:text-black md:text-12'
+          cssOption='text-center mt-[24px] whitespace-nowrap rounded-[10px] bg-blue p-[16px] text-[1vw] text-white hover:text-black w-[100%]'
         />
       </div>
-      <div className='mt-auto pb-24'>
+      <div className='mt-auto pb-[24px]'>
         <NavbarContact />
       </div>
     </aside>

--- a/frontend/src/component/organism/NavbarSelectWrapper.tsx
+++ b/frontend/src/component/organism/NavbarSelectWrapper.tsx
@@ -14,7 +14,7 @@ export default function NavbarSelectWrapper() {
   const duckAnimation = useDuckAnimation({ containerRef });
 
   return (
-    <div className='relative mt-8 w-full'>
+    <div className='relative mt-[8px] w-full'>
       <div ref={containerRef}>
         {!isProjectPath ? (
           <NavbarDefaultSelect />

--- a/frontend/src/component/organism/ProjectDAU.tsx
+++ b/frontend/src/component/organism/ProjectDAU.tsx
@@ -23,11 +23,10 @@ export default function ProjectDAU({ id }: Props) {
       }));
   }, [data]);
 
-
   if (validateDAU(data)) {
     return (
-      <DataLayout cssOption='flex flex-col items-center justify-center p-8 rounded-lg shadow-md w-full bg-white h-full'>
-        <div className='mb-8 text-center'>
+      <DataLayout cssOption='flex flex-col items-center justify-center p-[8px] rounded-lg shadow-md w-full bg-white h-full'>
+        <div className='mb-[8px] text-center'>
           <h2 className='text-navy text-2xl font-bold'>DAU</h2>
         </div>
         <div className='text-gray-500 flex w-full flex-1 items-center justify-center text-center'>
@@ -42,20 +41,20 @@ export default function ProjectDAU({ id }: Props) {
   thirtyDaysAgo.setDate(today.getDate() - 30);
 
   return (
-    <DataLayout cssOption='flex flex-col items-center justify-center p-8 rounded-lg shadow-md w-full bg-white h-full'>
-      <div className='mb-8 text-center'>
-        <h2 className='text-navy text-2xl font-bold'>DAU</h2>
+    <DataLayout cssOption='flex flex-col items-center justify-center p-[8px] rounded-lg shadow-md w-full bg-white h-full'>
+      <div className='mb-[8px] text-center'>
+        <h2 className='text-navy text-[1.5vw] font-bold'>DAU</h2>
       </div>
-      <div className='h-full w-full'>
+      <div className='flex h-[90%] w-[100%] items-center'>
         <ResponsiveTimeRange
           data={series}
           from={thirtyDaysAgo}
           to={today}
           colors={['#ebedf0', '#40c463', '#30a14e', '#216e39']}
-          margin={{ top: 20, right: 40, bottom: 20, left: 40 }}
           dayBorderWidth={2}
           dayBorderColor='#ffffff'
           weekdayTicks={[]}
+          margin={{ top: 20, bottom: 100 }}
           tooltip={({ day, value }) => (
             <div
               style={{
@@ -68,6 +67,13 @@ export default function ProjectDAU({ id }: Props) {
               {new Date(day).toLocaleDateString('ko-KR')}: {value.toLocaleString()}명
             </div>
           )}
+          theme={{
+            labels: {
+              text: {
+                fill: '#9CA3AF'
+              }
+            }
+          }}
         />
       </div>
     </DataLayout>

--- a/frontend/src/component/organism/ProjectDAU.tsx
+++ b/frontend/src/component/organism/ProjectDAU.tsx
@@ -2,7 +2,6 @@ import DataLayout from '@component/template/DataLayout';
 import useProjectDAU from '@hook/api/useProjectDAU';
 import { ResponsiveTimeRange } from '@nivo/calendar';
 import { validateDAU } from '@util/Validate';
-import { useMemo } from 'react';
 
 type Props = {
   id: string;
@@ -10,18 +9,16 @@ type Props = {
 
 export default function ProjectDAU({ id }: Props) {
   const { data } = useProjectDAU(id);
+  const today = new Date();
+  const thirtyDaysAgo = new Date(today);
+  thirtyDaysAgo.setDate(today.getDate() - 30);
 
-  const series = useMemo(() => {
-    const thirtyDaysAgo = new Date();
-    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
-
-    return data.dauRecords
-      .filter(({ date }) => new Date(date) >= thirtyDaysAgo)
-      .map(({ date, dau }) => ({
-        day: date,
-        value: dau
-      }));
-  }, [data]);
+  const series = data.dauRecords
+    .filter(({ date }) => new Date(date) >= thirtyDaysAgo)
+    .map(({ date, dau }) => ({
+      day: date,
+      value: dau
+    }));
 
   if (validateDAU(data)) {
     return (
@@ -35,10 +32,6 @@ export default function ProjectDAU({ id }: Props) {
       </DataLayout>
     );
   }
-
-  const today = new Date();
-  const thirtyDaysAgo = new Date(today);
-  thirtyDaysAgo.setDate(today.getDate() - 30);
 
   return (
     <DataLayout cssOption='flex flex-col items-center justify-center p-[8px] rounded-lg shadow-md w-full bg-white h-full'>

--- a/frontend/src/component/organism/ProjectSuccessRate.tsx
+++ b/frontend/src/component/organism/ProjectSuccessRate.tsx
@@ -59,9 +59,9 @@ export default function ProjectSuccessRate({ id }: Props) {
   };
 
   return (
-    <DataLayout cssOption='flex flex-col p-8 rounded-lg shadow-md w-full h-full'>
-      <div className='mb-8 text-center'>
-        <h2 className='text-navy text-2xl font-bold'>Request Success Rate</h2>
+    <DataLayout cssOption='flex flex-col p-[8px] rounded-lg shadow-md w-full h-full'>
+      <div className='mb-[8px] text-center'>
+        <h2 className='text-navy text-[1.5vw] font-bold'>Request Success Rate</h2>
       </div>
       <div className='w-full flex-1'>
         <PieChart options={options} series={series} />

--- a/frontend/src/component/organism/ProjectTrafficChart.tsx
+++ b/frontend/src/component/organism/ProjectTrafficChart.tsx
@@ -13,6 +13,7 @@ type Props = {
 export default function ProjectTrafficChart({ id }: Props) {
   const [dateType, setDateType] = useState<DateType>('day');
   const { data } = useProjectTraffic(id, dateType);
+  console.log(data);
 
   const handleDateTypeChange = (type: DateType) => {
     setDateType(type);
@@ -78,22 +79,6 @@ export default function ProjectTrafficChart({ id }: Props) {
     const xAxisConfig = getXAxisFormatter(dateType);
 
     return {
-      chart: {
-        toolbar: {
-          show: true,
-          tools: {
-            download: true,
-            zoomin: false,
-            zoomout: false,
-            pan: false,
-            reset: false,
-            selection: false
-          }
-        },
-        zoom: {
-          enabled: false
-        }
-      },
       xaxis: {
         type: 'datetime',
         ...xAxisConfig,
@@ -101,6 +86,10 @@ export default function ProjectTrafficChart({ id }: Props) {
           colors: '#6B7280'
         },
         labels: {
+          style: {
+            colors: '#64748B',
+            fontSize: '12px'
+          },
           ...xAxisConfig,
           rotateAlways: false,
           hideOverlappingLabels: true
@@ -144,19 +133,20 @@ export default function ProjectTrafficChart({ id }: Props) {
 
   if (data.trafficData.length === 0) {
     return (
-      <DataLayout cssOption='flex flex-col p-8 rounded-lg shadow-md w-full h-full justify-center'>
+      <DataLayout cssOption='flex flex-col p-[8px] rounded-lg shadow-md w-full h-full justify-center'>
         <span className='text-center'>No data availiable</span>
       </DataLayout>
     );
   }
 
   return (
-    <DataLayout cssOption='flex flex-col p-8 rounded-lg shadow-md w-full h-full'>
-      <div className='mb-8 flex items-center justify-between'>
-        <div className='flex-1'></div>
-        <h2 className='text-navy text-center text-2xl font-bold'>
-          {data.projectName} Traffic Chart
-        </h2>
+    <DataLayout cssOption='flex flex-col p-[8px] rounded-lg shadow-md w-full h-full'>
+      <div className='mb-[8px] flex items-center justify-between'>
+        <div className='flex-1 items-center pl-12 pt-2 text-xl text-gray'>Total: {data.total}</div>
+        <div className='text-navy items-center text-center text-xl'>
+          <span className='mr-2 text-2xl font-bold'>{data.projectName}</span>
+          Traffic Chart
+        </div>
         <div className='flex flex-1 justify-end'>
           <Select
             cssOption='p-2 border rounded'

--- a/frontend/src/component/organism/ProjectTrafficChart.tsx
+++ b/frontend/src/component/organism/ProjectTrafficChart.tsx
@@ -4,7 +4,7 @@ import DataLayout from '@component/template/DataLayout';
 import { DATE_OPTIONS } from '@constant/Date';
 import useProjectTraffic from '@hook/api/useProjectTraffic';
 import { DateType } from '@type/Date';
-import { useState, useMemo } from 'react';
+import { useState } from 'react';
 
 type Props = {
   id: string;
@@ -19,117 +19,109 @@ export default function ProjectTrafficChart({ id }: Props) {
     setDateType(type);
   };
 
-  const series = useMemo(
-    () => [
-      {
-        name: data.projectName || 'Unknown',
-        data: data.trafficData.map((item) => ({
-          x: new Date(item.timestamp),
-          y: Number(item.count)
-        }))
-      }
-    ],
-    [data]
-  );
+  const series = [
+    {
+      name: data.projectName || 'Unknown',
+      data: data.trafficData.map((item) => ({
+        x: new Date(item.timestamp),
+        y: Number(item.count)
+      }))
+    }
+  ];
 
-  const options: ApexCharts.ApexOptions = useMemo(() => {
-    const getXAxisFormatter = (type: DateType) => {
-      switch (type) {
-        case 'day':
-          return {
-            formatter: function (value: string, timestamp: number) {
-              if (!timestamp) return value;
-              const date = new Date(timestamp);
+  const getXAxisFormatter = (type: DateType) => {
+    switch (type) {
+      case 'day':
+        return {
+          formatter: function (value: string, timestamp: number) {
+            if (!timestamp) return value;
+            const date = new Date(timestamp);
+            return date.toLocaleString('ko-KR', {
+              hour: '2-digit',
+              minute: '2-digit',
+              hour12: true
+            });
+          },
+          tickAmount: 24
+        };
+      case 'week':
+        return {
+          formatter: function (value: string, timestamp: number) {
+            if (!timestamp) return value;
+            const date = new Date(timestamp);
+            return date.toLocaleString('ko-KR', {
+              month: 'short',
+              day: 'numeric',
+              weekday: 'short'
+            });
+          },
+          tickAmount: 7
+        };
+      case 'month':
+        return {
+          formatter: function (value: string, timestamp: number) {
+            if (!timestamp) return value;
+            const date = new Date(timestamp);
+            return date.toLocaleString('ko-KR', {
+              month: 'short',
+              day: 'numeric'
+            });
+          },
+          tickAmount: 31
+        };
+    }
+  };
+
+  const xAxisConfig = getXAxisFormatter(dateType);
+
+  const options: ApexCharts.ApexOptions = {
+    xaxis: {
+      type: 'datetime',
+      ...xAxisConfig,
+      labels: {
+        style: {
+          colors: '#64748B',
+          fontSize: '12px'
+        },
+        ...xAxisConfig,
+        rotateAlways: false,
+        hideOverlappingLabels: true
+      }
+    },
+    yaxis: {
+      labels: {
+        style: {
+          colors: '#6B7280'
+        }
+      }
+    },
+    tooltip: {
+      x: {
+        formatter: function (val: number) {
+          const date = new Date(val);
+          switch (dateType) {
+            case 'day':
               return date.toLocaleString('ko-KR', {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
                 hour: '2-digit',
                 minute: '2-digit',
                 hour12: true
               });
-            },
-            tickAmount: 24
-          };
-        case 'week':
-          return {
-            formatter: function (value: string, timestamp: number) {
-              if (!timestamp) return value;
-              const date = new Date(timestamp);
+            case 'week':
+            case 'month':
               return date.toLocaleString('ko-KR', {
-                month: 'short',
+                year: 'numeric',
+                month: 'long',
                 day: 'numeric',
-                weekday: 'short'
+                weekday: 'long'
               });
-            },
-            tickAmount: 7
-          };
-        case 'month':
-          return {
-            formatter: function (value: string, timestamp: number) {
-              if (!timestamp) return value;
-              const date = new Date(timestamp);
-              return date.toLocaleString('ko-KR', {
-                month: 'short',
-                day: 'numeric'
-              });
-            },
-            tickAmount: 31
-          };
-      }
-    };
-
-    const xAxisConfig = getXAxisFormatter(dateType);
-
-    return {
-      xaxis: {
-        type: 'datetime',
-        ...xAxisConfig,
-        style: {
-          colors: '#6B7280'
-        },
-        labels: {
-          style: {
-            colors: '#64748B',
-            fontSize: '12px'
-          },
-          ...xAxisConfig,
-          rotateAlways: false,
-          hideOverlappingLabels: true
-        }
-      },
-      yaxis: {
-        labels: {
-          style: {
-            colors: '#6B7280'
-          }
-        }
-      },
-      tooltip: {
-        x: {
-          formatter: function (val: number) {
-            const date = new Date(val);
-            switch (dateType) {
-              case 'day':
-                return date.toLocaleString('ko-KR', {
-                  year: 'numeric',
-                  month: 'long',
-                  day: 'numeric',
-                  hour: '2-digit',
-                  minute: '2-digit',
-                  hour12: true
-                });
-              case 'week':
-              case 'month':
-                return date.toLocaleString('ko-KR', {
-                  year: 'numeric',
-                  month: 'long',
-                  day: 'numeric',
-                  weekday: 'long'
-                });
-            }
           }
         }
       }
-    };
-  }, [dateType]);
+    }
+  };
 
   if (data.trafficData.length === 0) {
     return (

--- a/frontend/src/component/organism/RankingList.tsx
+++ b/frontend/src/component/organism/RankingList.tsx
@@ -14,9 +14,9 @@ export default function RankingList({ generation }: Props) {
   const { data } = useRankData(rankType, generation);
 
   return (
-    <DataLayout cssOption='p-8 rounded-lg shadow-md w-full justify-center flex-col flex h-full'>
+    <DataLayout cssOption='p-[8px] rounded-lg shadow-md w-full justify-center flex-col flex h-full'>
       <div className='flex h-full w-full flex-col'>
-        <div className='mb-16 ml-8'>
+        <div className='mb-[16px] ml-[8px]'>
           <RankingTab rankType={rankType} setRankType={setRankType} />
         </div>
         <div className='flex h-full justify-center'>

--- a/frontend/src/component/organism/RegisterDescription.tsx
+++ b/frontend/src/component/organism/RegisterDescription.tsx
@@ -4,13 +4,13 @@ import RegisterText from '@component/molecule/RegisterText';
 export default function RegisterDescription() {
   return (
     <div className='flex h-screen flex-col shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] dark:text-white'>
-      <div className='flex-1 overflow-y-auto p-40'>
+      <div className='flex-1 overflow-y-auto p-[40px]'>
         <RegisterText />
       </div>
       <NavigateButton
         path='/'
         content='메인으로'
-        cssOption='bg-blue w-full rounded-[10px] text-white text-[25px] px-[100px] py-[10px] flex items-center justify-center whitespace-nowrap hover:text-black mx-[40px] my-[20px]'
+        cssOption='bg-blue w-[80%] rounded-[10px] text-white text-[25px] py-[10px] flex items-center justify-center whitespace-nowrap hover:text-black mx-[40px] my-[20px]'
       />
     </div>
   );

--- a/frontend/src/component/organism/RegisterForm.tsx
+++ b/frontend/src/component/organism/RegisterForm.tsx
@@ -3,10 +3,9 @@ import H1 from '@component/atom/H1';
 import H2 from '@component/atom/H2';
 import Select from '@component/atom/Select';
 import ValidateTextInput from '@component/molecule/ValidateTextInput';
+import { GENERATION_OPTION } from '@constant/NavbarSelect';
 import useRegisterForm from '@hook/useRegisterForm';
 import { useRef, useEffect } from 'react';
-
-import { GENERATION_OPTION } from '@/constant/NavbarSelect';
 
 type Props = {
   showAlert: (message: string) => void;
@@ -34,9 +33,12 @@ export default function RegisterForm({ showAlert }: Props) {
   }, []);
 
   return (
-    <div className='mx-auto flex w-full max-w-[600px] flex-col items-center gap-16 rounded-lg bg-white/25 p-6 shadow-[4px_9px_50px_-1px_rgba(0,0,0,0.25)] backdrop-blur-[30px] md:gap-24 md:rounded-31 md:p-50 dark:shadow-[4px_9px_50px_-1px_rgba(255,255,255,0.2)]'>
-      <H1 cssOption='text-blue font-bold text-24 md:text-50' content='Register' />
-      <H2 cssOption='text-gray text-18 md:text-24' content='그룹 프로젝트를 등록해 주세요' />
+    <div className='mx-6 mx-auto flex w-full max-w-[600px] flex-col items-center gap-[16px] rounded-lg bg-white/25 p-6 shadow-[4px_9px_50px_-1px_rgba(0,0,0,0.25)] backdrop-blur-[30px] dark:shadow-[4px_9px_50px_-1px_rgba(255,255,255,0.1)] md:gap-[24px] md:rounded-[31px] md:p-[50px]'>
+      <H1 cssOption='text-blue font-bold text-[24px] md:text-[50px]' content='Register' />
+      <H2
+        cssOption='text-gray text-[18px] md:text-[24px]'
+        content='그룹 프로젝트를 등록해 주세요'
+      />
 
       <ValidateTextInput
         ref={nameInputRef}
@@ -72,17 +74,17 @@ export default function RegisterForm({ showAlert }: Props) {
       />
 
       <Select
-        cssOption='w-full py-2 px-4 rounded-1.5 border border-gray'
+        cssOption='w-full py-2 px-4 rounded-[1.5px] border border-gray'
         options={GENERATION_OPTION}
         value={formData.generation}
         onChange={handleSelectChange('generation')}
       />
 
       <Button
-        cssOption={`bg-blue rounded-10 text-white
-                   text-16 md:text-24
-                   px-16 md:px-130
-                   py-8 md:py-15
+        cssOption={`bg-blue rounded-[10px] text-white
+                   text-16 md:text-[24px]
+                   px-[16px] md:px-[130px]
+                   py-[8px] md:py-[15px]
                    flex items-center justify-center whitespace-nowrap
                    hover:text-black
                    disabled:opacity-50

--- a/frontend/src/component/page/ErrorPage.tsx
+++ b/frontend/src/component/page/ErrorPage.tsx
@@ -42,7 +42,7 @@ export default function ErrorPage() {
         <NavigateButton
           path='/'
           content='Go To Main'
-          cssOption='text-white bg-blue px-8 py-3 rounded-md hover:bg-blue-600 transition-all duration-300 shadow-md hover:shadow-lg font-semibold mt-4 hover:text-black'
+          cssOption='text-white bg-blue px-[8px] py-3 rounded-md hover:bg-blue-600 transition-all duration-300 shadow-md hover:shadow-lg font-semibold mt-4 hover:text-black'
         />
       </div>
     </div>

--- a/frontend/src/component/page/MainPage.tsx
+++ b/frontend/src/component/page/MainPage.tsx
@@ -8,8 +8,8 @@ export default function MainPage() {
   const generation = useNavbarStore((state) => state.generation);
 
   return (
-    <div className='flex h-screen w-full flex-col gap-8 bg-lightgray p-8 dark:bg-lightblack'>
-      <div className='mt-8 grid h-1/2 grid-cols-1 gap-8 lg:grid-cols-2'>
+    <div className='flex h-screen w-full flex-col gap-[8px] p-[8px]'>
+      <div className='mt-[8px] grid h-1/2 grid-cols-1 gap-[8px] md:grid-cols-2'>
         <CustomErrorBoundary>
           <MainData generation={generation} />
         </CustomErrorBoundary>

--- a/frontend/src/component/page/ProjectDetailPage.tsx
+++ b/frontend/src/component/page/ProjectDetailPage.tsx
@@ -22,8 +22,8 @@ export default function ProjectDetailPage() {
   }
 
   return (
-    <div className='flex h-screen w-full flex-col bg-lightgray p-8 dark:bg-lightblack'>
-      <div className='flex h-1/2 gap-8'>
+    <div className='flex h-screen w-full flex-col p-[8px]'>
+      <div className='flex h-1/2 gap-[8px]'>
         <div className='h-full w-1/3'>
           <CustomErrorBoundary>
             <ProjectElapsedTime id={id} />
@@ -41,7 +41,7 @@ export default function ProjectDetailPage() {
         </div>
       </div>
 
-      <div className='mt-8 h-1/2'>
+      <div className='mt-[8px] h-1/2'>
         <CustomErrorBoundary>
           <ProjectTrafficChart id={id} />
         </CustomErrorBoundary>

--- a/frontend/src/component/page/RankingPage.tsx
+++ b/frontend/src/component/page/RankingPage.tsx
@@ -6,7 +6,7 @@ export default function RankingPage() {
   const { generation } = useNavbarStore();
 
   return (
-    <div className='flex h-screen w-full flex-col gap-8 bg-lightgray p-16 dark:bg-lightblack'>
+    <div className='flex h-screen w-full flex-col gap-[8px] p-[16px]'>
       <CustomErrorBoundary>
         <RankingList generation={generation} />
       </CustomErrorBoundary>

--- a/frontend/src/component/page/RegisterPage.tsx
+++ b/frontend/src/component/page/RegisterPage.tsx
@@ -8,7 +8,7 @@ export default function RegisterPage() {
 
   return (
     <>
-      <div className='dark:bg-lightblack relative my-auto flex h-full w-full flex-col items-center justify-center gap-50 pl-50 md:flex-row'>
+      <div className='relative mx-auto my-auto flex h-full w-full flex-col items-center justify-center gap-[50px] md:flex-row'>
         <RegisterForm showAlert={showAlert} />
         <RegisterDescription />
       </div>
@@ -17,7 +17,7 @@ export default function RegisterPage() {
         <Alert
           content={message}
           isVisible={isVisible}
-          cssOption='text-18 border-2 border-white shadow-[4px_9px_50px_-1px_rgba(0,0,0,0.25)] z-[50] rounded-31 p-40 backdrop-blur-[30px] bg-white'
+          cssOption='text-[18px] border-[2px] border-white shadow-[4px_9px_50px_-1px_rgba(0,0,0,0.25)] z-[50] rounded-[31px] p-[40px] backdrop-blur-[30px] bg-white'
         />
       )}
     </>

--- a/frontend/src/component/template/DataLayout.tsx
+++ b/frontend/src/component/template/DataLayout.tsx
@@ -5,7 +5,8 @@ type Props = {
 
 export default function DataLayout({ children, cssOption }: Props) {
   return (
-    <div className={`${cssOption} dark:bg-darkblue bg-white hover:shadow-lg dark:text-white`}>
+    <div
+      className={`${cssOption} bg-white hover:shadow-lg dark:bg-darkblue dark:text-white dark:hover:shadow-[0_35px_60px_-15px_rgba(0,0,0,1)]`}>
       {children}
     </div>
   );

--- a/frontend/src/component/template/MobileLayout.tsx
+++ b/frontend/src/component/template/MobileLayout.tsx
@@ -1,0 +1,14 @@
+export default function MobileLayout() {
+  return (
+    <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm'>
+      <div className='mx-4 rounded-lg bg-white p-6 text-center shadow-lg'>
+        <h2 className='text-navy mb-4 text-xl font-bold'>데스크톱으로 접속해주세요!</h2>
+        <p className='text-gray-600'>
+          이 서비스는 768px 이상의 화면에서 최적의 경험을 제공합니다.
+          <br />
+          데스크톱 환경에서 접속해주세요.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/component/template/NabvarLayout.tsx
+++ b/frontend/src/component/template/NabvarLayout.tsx
@@ -18,17 +18,16 @@ export default function NavbarLayout() {
 
   return (
     <div
-      className='relative'
+      className='relative h-screen w-[20%] rounded-[11px] bg-lightblue dark:bg-darkblue'
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}>
       <AnimatePresence>
         {isNavbarOpen && (
           <motion.div
             initial={{ width: 0, opacity: 0, x: -50 }}
-            animate={{ width: '300px', opacity: 1, x: 0 }}
+            animate={{ width: '100%', opacity: 1, x: 0 }}
             exit={{ width: 0, opacity: 0, x: -50 }}
-            transition={{ duration: 0.3, ease: 'easeInOut' }}
-            className='border-gray-200 border-r'>
+            transition={{ duration: 0.3, ease: 'easeInOut' }}>
             <Navbar />
             {isHovered && (
               <motion.button

--- a/frontend/src/hook/useIsMobile.ts
+++ b/frontend/src/hook/useIsMobile.ts
@@ -4,16 +4,19 @@ export default function useIsMobile(breakpoint: number = 768) {
   const [isMobile, setIsMobile] = useState<boolean>(false);
 
   useEffect(() => {
-    const checkScreenSize = () => {
-      setIsMobile(window.innerWidth < breakpoint);
+    const mediaQuery = `(max-width: ${breakpoint}px)`;
+
+    const mediaQueryList = window.matchMedia(mediaQuery);
+    setIsMobile(mediaQueryList.matches);
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      setIsMobile(event.matches);
     };
 
-    checkScreenSize();
-
-    window.addEventListener('resize', checkScreenSize);
+    mediaQueryList.addEventListener('change', handleChange);
 
     return () => {
-      window.removeEventListener('resize', checkScreenSize);
+      mediaQueryList.removeEventListener('change', handleChange);
     };
   }, [breakpoint]);
 

--- a/frontend/src/hook/useIsMobile.ts
+++ b/frontend/src/hook/useIsMobile.ts
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react';
+
+export default function useIsMobile(breakpoint: number = 768) {
+  const [isMobile, setIsMobile] = useState<boolean>(false);
+
+  useEffect(() => {
+    const checkScreenSize = () => {
+      setIsMobile(window.innerWidth < breakpoint);
+    };
+
+    checkScreenSize();
+
+    window.addEventListener('resize', checkScreenSize);
+
+    return () => {
+      window.removeEventListener('resize', checkScreenSize);
+    };
+  }, [breakpoint]);
+
+  return isMobile;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8,6 +8,14 @@ body {
   height: 100%;
 }
 
+body {
+  @apply bg-[#fcfcfc] dark:bg-[#00142B];
+}
+
+.apexcharts-menu-item {
+  color: black;
+}
+
 .apexcharts-xaxistooltip {
   display: none !important;
 }

--- a/frontend/src/store/NavbarStore.ts
+++ b/frontend/src/store/NavbarStore.ts
@@ -1,14 +1,6 @@
 import { BOOST_CAMP_OPTION, GENERATION_VALUE } from '@constant/NavbarSelect';
+import { NavbarState } from '@type/Navbar';
 import { create } from 'zustand';
-
-type NavbarState = {
-  generation: string;
-  selectedGroup: string;
-  isNavbarOpen: boolean;
-  setGeneration: (generation: string) => void;
-  setSelectedGroup: (group: string) => void;
-  toggleNavbar: (isOpen?: boolean) => void;
-};
 
 const useNavbarStore = create<NavbarState>((set) => ({
   generation: GENERATION_VALUE.NINTH,

--- a/frontend/src/type/Navbar.ts
+++ b/frontend/src/type/Navbar.ts
@@ -9,16 +9,19 @@ type MenuItem = {
   activeIcon: string;
   inactiveIcon: string;
 };
-type NavbarSelectProps = {
+
+type NavbarState = {
   generation: string;
   selectedGroup: string;
-  setGeneration: (value: string) => void;
-  setSelectedGroup: (value: string) => void;
-  groupOption?: GroupOption[];
+  isNavbarOpen: boolean;
+  setGeneration: (generation: string) => void;
+  setSelectedGroup: (group: string) => void;
+  toggleNavbar: (isOpen?: boolean) => void;
 };
+
 type Dimensions = {
   width: number;
   height: number;
 };
 
-export type { Generation, GroupOption, MenuItem, NavbarSelectProps, Dimensions };
+export type { Generation, GroupOption, MenuItem, NavbarState, Dimensions };

--- a/frontend/src/type/api.ts
+++ b/frontend/src/type/api.ts
@@ -52,6 +52,7 @@ type ProjectDAU = {
 type ProjectTraffic = {
   projectName: string;
   timeRange: string;
+  total: number;
   trafficData: {
     timestamp: string;
     count: number;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -10,9 +10,7 @@ export default {
         green: '#00DD4B',
         red: '#FF7676',
         black: '#001940',
-        lightgray: '#FCFCFC',
         lightblue: '#F3F8FC',
-        lightblack: '#00142B',
         darkblue: '#001F42'
       },
       fontWeight: {
@@ -20,50 +18,6 @@ export default {
         medium: '500',
         semibold: '600',
         bold: '700'
-      },
-      gap: {
-        8: '8px',
-        16: '16px'
-      },
-      padding: {
-        32: '32px'
-      },
-      spacing: {
-        8: '8px',
-        10: '10px',
-        12: '12px',
-        15: '15px',
-        16: '16px',
-        20: '20px',
-        24: '24px',
-        30: '30px',
-        40: '40px',
-        50: '50px',
-        130: '130px'
-      },
-      borderWidth: {
-        1.5: '1.5px',
-        2: '2px'
-      },
-      borderRadius: {
-        1.5: '1.5px',
-        10: '10px',
-        31: '31px'
-      },
-      height: {
-        40: '40px'
-      },
-      fontSize: {
-        8: '8px',
-        10: '10px',
-        12: '12px',
-        14: '14px',
-        18: '18px',
-        24: '24px',
-        25: '25px',
-        30: '30px',
-        36: '36px',
-        50: '50px'
       }
     }
   },


### PR DESCRIPTION
### 👀 관련 이슈
#228

### ✨ 작업한 내용

1. 반응형 설정을 했습니다.
일단 768px을 기준으로 그 이하가 되면 데스크탑으로 접속해달라는 오버레이를 띄우도록했습니다.
그 전 까진, 크기가 줄어들어도 형태는 유지되도록 값들을 수정했습니다.
text -> vw단위 사용
w,h -> %사용

2. 제목옆에 오리 이미지를 교체했습니다.
3. 개별프로젝트페이지에서 TotalTrafficCount를 띄우도록 추가했습니다.
4. ResponseTime을 Fastest, Slowest2개로 나누었습니다.


### 📷 스크린샷 또는 GIF
<img width="803" alt="image" src="https://github.com/user-attachments/assets/a31b08cd-3bfb-4a98-b46b-1486bef9a609">

<img width="1437" alt="image" src="https://github.com/user-attachments/assets/f10a9736-b7c0-42db-8d7d-137b7327e757">
