### PR TITLE
[FE] 개별 프로젝트 페이지 화면 확대시, 소제목이 차트와 겹치던현상

### DIFF
--- a/frontend/src/component/molecule/NavbarContact.tsx
+++ b/frontend/src/component/molecule/NavbarContact.tsx
@@ -8,10 +8,10 @@ export default function NavbarContact() {
   return (
     <div className='flex w-[100%] items-center gap-2'>
       <Link to={PATH.GITHUB} target='_blank' className='flex-shrink-0'>
-        <Img src={GithubImg} alt='깃허브 이미지' cssOption='w-[24px] h-[24px] dark:invert' />
+        <Img src={GithubImg} alt='깃허브 이미지' cssOption='w-[20px] h-[20px] dark:invert' />
       </Link>
       <P
-        cssOption='text-[0.6vw] flex items-center whitespace-nowrap truncate text-gray'
+        cssOption='text-[0.7vw] flex items-center whitespace-nowrap truncate text-gray'
         content='Contact us : shson1217@naver.com'
       />
     </div>

--- a/frontend/src/component/molecule/NavbarRanking.tsx
+++ b/frontend/src/component/molecule/NavbarRanking.tsx
@@ -29,7 +29,7 @@ export default function NavbarRanking() {
               <Fragment>
                 <Img
                   src={MEDALS[rank as keyof typeof MEDALS].image}
-                  cssOption='flex-shrink-0 w-5'
+                  cssOption='flex-shrink-0 w-4'
                   alt={`${rank + 1}번째 메달`}
                 />
                 <P
@@ -40,7 +40,7 @@ export default function NavbarRanking() {
             ) : (
               <Fragment>
                 <Span
-                  cssOption='w-6 flex-shrink-0 font-medium dark:text-white'
+                  cssOption='w-5 h-5 flex-shrink-0 font-medium dark:text-white'
                   content={`${rank + 1}th`}
                 />
                 <P cssOption='truncate dark:text-white max-w-[140px]' content={item.projectName} />
@@ -61,9 +61,11 @@ export default function NavbarRanking() {
   };
 
   return (
-    <div className='mt-[8px] rounded-[10px] border-[1.5px] border-solid border-gray p-4'>
-      <P cssOption='text-[0.9vw] mb-1 font-bold dark:text-white' content='TRAFFIC RANKING' />
-      {data.rank.map((item, index) => renderRankingItem(item, index))}
+    <div className='rounded-[10px] border-[1.5px] border-solid border-gray p-4'>
+      <P cssOption='text-xs mb-2 font-bold dark:text-white' content='TRAFFIC RANKING' />
+      <div className='overflow-y-auto'>
+        {data.rank.map((item, index) => renderRankingItem(item, index))}
+      </div>
     </div>
   );
 }

--- a/frontend/src/component/molecule/ProjectElapsedTimeLegend.tsx
+++ b/frontend/src/component/molecule/ProjectElapsedTimeLegend.tsx
@@ -14,18 +14,24 @@ export default function ProjectElapsedTimeLegend({ averageTime }: Props) {
   };
 
   return (
-    <div className='flex flex-col items-center gap-4'>
+    <div className='flex w-full flex-col items-center gap-4'>
       <div className='text-center'>
-        <H2 cssOption='text-navy mb-4 text-[1vw] font-bold' content='TOP3 Average Response Speed' />
-        <div className='mb-4 text-[2vw] font-bold' style={{ color: getColorByTime(averageTime) }}>
+        <H2
+          cssOption='text-navy mb-2 text-[0.9vw] font-bold'
+          content='TOP3 Average Response Speed'
+        />
+        <div className='text-[1.5vw] font-bold' style={{ color: getColorByTime(averageTime) }}>
           {averageTime || 0}ms
         </div>
       </div>
-      <div className='text-gray-500 flex items-center justify-center gap-4 text-[10px]'>
+      <div className='flex items-center justify-center gap-4'>
         {RESPONSE_TIME_LEGENDS.map((item, index) => (
           <div key={index} className='flex items-center gap-2'>
-            <Span cssOption='h-3 w-3 rounded-full block' style={{ backgroundColor: item.color }} />
-            <Span cssOption='text-gray-500' content={`${item.range} ${item.description}`} />
+            <Span cssOption='h-2 w-2 rounded-full block' style={{ backgroundColor: item.color }} />
+            <Span
+              cssOption='text-gray-500 text-[0.7vw]'
+              content={`${item.range} ${item.description}`}
+            />
           </div>
         ))}
       </div>

--- a/frontend/src/component/organism/NavBar.tsx
+++ b/frontend/src/component/organism/NavBar.tsx
@@ -8,22 +8,24 @@ import NavbarSelectWrapper from '@component/organism/NavbarSelectWrapper';
 
 export default function Navbar() {
   return (
-    <aside className='border-3 flex h-screen flex-col rounded-[11px] bg-lightblue p-[24px] dark:bg-darkblue'>
-      <div className='flex flex-col gap-[16px] pt-[24px]'>
-        <NavbarTitle />
-        <NavbarSelectWrapper />
-        <NavbarMenu />
-        <CustomErrorBoundary>
-          <NavbarRanking />
-        </CustomErrorBoundary>
-        <NavigateButton
-          path='/register'
-          content='프로젝트 등록하러가기'
-          cssOption='text-center mt-[24px] whitespace-nowrap rounded-[10px] bg-blue p-[16px] text-[1vw] text-white hover:text-black w-[100%]'
-        />
-      </div>
-      <div className='mt-auto pb-[24px]'>
-        <NavbarContact />
+    <aside className='border-3 flex h-screen flex-col overflow-hidden rounded-[11px] bg-lightblue p-[24px] dark:bg-darkblue'>
+      <div className='flex min-h-0 flex-1 flex-col'>
+        <div className='flex flex-col gap-[16px] overflow-auto pt-[24px]'>
+          <NavbarTitle />
+          <NavbarSelectWrapper />
+          <NavbarMenu />
+          <CustomErrorBoundary>
+            <NavbarRanking />
+          </CustomErrorBoundary>
+          <NavigateButton
+            path='/register'
+            content='프로젝트 등록하러가기'
+            cssOption='text-center mt-[24px] whitespace-nowrap rounded-[10px] bg-blue p-[16px] text-[10px] md:text-[12px] lg:text-[14px] text-white hover:text-black w-[100%]'
+          />
+        </div>
+        <div className='mt-auto pb-[24px] pt-[12px]'>
+          <NavbarContact />
+        </div>
       </div>
     </aside>
   );

--- a/frontend/src/component/organism/NavBar.tsx
+++ b/frontend/src/component/organism/NavBar.tsx
@@ -8,23 +8,34 @@ import NavbarSelectWrapper from '@component/organism/NavbarSelectWrapper';
 
 export default function Navbar() {
   return (
-    <aside className='border-3 flex h-screen flex-col overflow-hidden rounded-[11px] bg-lightblue p-[24px] dark:bg-darkblue'>
+    <aside className='border-3 flex h-screen min-h-0 flex-col rounded-[11px] bg-lightblue p-4 dark:bg-darkblue'>
       <div className='flex min-h-0 flex-1 flex-col'>
-        <div className='flex flex-col gap-[16px] overflow-auto pt-[24px]'>
-          <NavbarTitle />
-          <NavbarSelectWrapper />
-          <NavbarMenu />
-          <CustomErrorBoundary>
-            <NavbarRanking />
-          </CustomErrorBoundary>
-          <NavigateButton
-            path='/register'
-            content='프로젝트 등록하러가기'
-            cssOption='text-center mt-[24px] whitespace-nowrap rounded-[10px] bg-blue p-[16px] text-[10px] md:text-[12px] lg:text-[14px] text-white hover:text-black w-[100%]'
-          />
-        </div>
-        <div className='mt-auto pb-[24px] pt-[12px]'>
-          <NavbarContact />
+        <div className='flex min-h-0 flex-1 flex-col justify-between'>
+          <div className='flex min-h-0 flex-col space-y-4'>
+            <div className='flex-shrink-0 space-y-2'>
+              <NavbarTitle />
+              <NavbarSelectWrapper />
+            </div>
+            <div className='flex-shrink-0'>
+              <NavbarMenu />
+            </div>
+            <div className='min-h-0 flex-1 overflow-y-scroll'>
+              <CustomErrorBoundary>
+                <NavbarRanking />
+              </CustomErrorBoundary>
+            </div>
+            <div className='flex-shrink-0'>
+              <NavigateButton
+                path='/register'
+                content='프로젝트 등록하러가기'
+                cssOption='text-center whitespace-nowrap rounded-[10px] bg-blue p-3 text-[0.8vw] text-white hover:text-black w-full'
+              />
+            </div>
+          </div>
+
+          <div className='flex-shrink-0 pt-4'>
+            <NavbarContact />
+          </div>
         </div>
       </div>
     </aside>

--- a/frontend/src/component/organism/ProjectElapsedTime.tsx
+++ b/frontend/src/component/organism/ProjectElapsedTime.tsx
@@ -83,13 +83,18 @@ export default function ProjectElapsedTime({ id }: Props) {
   return (
     <DataLayout cssOption='flex flex-col p-[8px] rounded-lg shadow-md w-full h-full'>
       <div className='flex h-full flex-col'>
-        <div className='mb-4'>
+        {/* 제목 */}
+        <div className='mb-6'>
           <h2 className='text-navy text-center text-[1.5vw] font-bold'>Response Speed</h2>
         </div>
-        <div className='grid min-h-0 flex-1 grid-cols-2 gap-4'>
+
+        {/* 차트 영역 */}
+        <div className='grid h-[50%] flex-1 grid-cols-2 gap-4'>
+          {' '}
+          {/* 고정된 높이 비율 */}
           <div className='flex flex-col'>
             <h3 className='mb-2 text-center text-[1vw] font-semibold text-green'>Fastest Paths</h3>
-            <div className='min-h-0 flex-1'>
+            <div className='flex-1'>
               <PolarAreaChart
                 options={{
                   ...fastestOptions,
@@ -101,7 +106,7 @@ export default function ProjectElapsedTime({ id }: Props) {
           </div>
           <div className='flex flex-col'>
             <h3 className='mb-2 text-center text-[1vw] font-semibold text-red'>Slowest Paths</h3>
-            <div className='min-h-0 flex-1'>
+            <div className='flex-1'>
               <PolarAreaChart
                 options={{
                   ...slowestOptions,
@@ -112,7 +117,7 @@ export default function ProjectElapsedTime({ id }: Props) {
             </div>
           </div>
         </div>
-        <div className='mt-auto pt-4'>
+        <div className='flex flex-1 items-center justify-center'>
           <ProjectElapsedTimeLegend averageTime={getAverageResponseTime()} />
         </div>
       </div>


### PR DESCRIPTION
### 👀 관련 이슈
#269

### ✨ 작업한 내용

1. 화면 확대 시, Top3 Average Response Speed 제목이 Response Speed차트와 겹치던 현상을 수정했습니다.
2 화면 확대 시,  Navbar를 요소들이 넘치던 현상 수정

### 🌀 PR Point

1번의 경우 gap을 더 줬고, 글씨크기를 반응형으로 수정했습니다.
2번의 경우 flex-1로 채우고, overflow-y-scroll로 navbar랭킹을 스크롤로 보도록 수정했습니다!


### 📷 스크린샷 또는 GIF

<img width="1158" alt="image" src="https://github.com/user-attachments/assets/2569c516-1224-450b-9e42-a42bd70dfab1">


<img width="306" alt="image" src="https://github.com/user-attachments/assets/13150ee2-3746-4e1a-b86b-b00b05657516">
