### PR TITLE
[FE] 랭킹페이지에 정보 버튼 추가

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "react-error-boundary": "^4.1.2",
         "react-router-dom": "^6.27.0",
         "react-toastify": "^10.0.6",
+        "tailwind-scrollbar-hide": "^1.1.7",
         "zustand": "^5.0.1"
       },
       "devDependencies": {
@@ -6224,6 +6225,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/tailwind-scrollbar-hide": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/tailwind-scrollbar-hide/-/tailwind-scrollbar-hide-1.1.7.tgz",
+      "integrity": "sha512-X324n9OtpTmOMqEgDUEA/RgLrNfBF/jwJdctaPZDzB3mppxJk7TLIDmOreEDm1Bq4R9LSPu4Epf8VSdovNU+iA==",
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "3.4.14",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "react-error-boundary": "^4.1.2",
     "react-router-dom": "^6.27.0",
     "react-toastify": "^10.0.6",
+    "tailwind-scrollbar-hide": "^1.1.7",
     "zustand": "^5.0.1"
   },
   "devDependencies": {

--- a/frontend/src/component/molecule/InformationButton.tsx
+++ b/frontend/src/component/molecule/InformationButton.tsx
@@ -1,0 +1,34 @@
+import { Info } from 'lucide-react';
+import { useState } from 'react';
+
+type Props = {
+  text: string;
+};
+
+export default function InformationButton({ text }: Props) {
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  return (
+    <div
+      className='relative inline-flex items-center'
+      onMouseEnter={() => setShowTooltip(true)}
+      onMouseLeave={() => setShowTooltip(false)}>
+      <button
+        className='bg-gray-100 hover:bg-gray-200 flex h-8 w-8 items-center justify-center rounded-full transition-colors'
+        aria-label='정보 보기'>
+        <Info className='text-gray-500 h-4 w-4' />
+      </button>
+
+      {showTooltip && (
+        <div className='absolute right-full top-1/2 mr-2 -translate-y-1/2'>
+          <div className='relative'>
+            <div className='bg-gray-800 absolute left-full top-1/2 h-2 w-2 -translate-y-1/2 rotate-45 transform' />
+            <div className='bg-gray-800 whitespace-nowrap rounded-lg px-3 py-2 text-[1vw] text-black shadow-lg dark:text-white'>
+              {text}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/component/molecule/RankingTab.tsx
+++ b/frontend/src/component/molecule/RankingTab.tsx
@@ -1,3 +1,4 @@
+import InformationButton from '@component/molecule/InformationButton';
 import { RANK_OPTIONS } from '@constant/Rank';
 import { RankType } from '@type/Rank';
 
@@ -8,15 +9,20 @@ type Props = {
 
 export default function RankingTab({ rankType, setRankType }: Props) {
   return (
-    <div className='border-gray-200 flex border-b'>
-      {RANK_OPTIONS.map((option) => (
-        <button
-          key={option.value}
-          className={`px-4 py-2 ${option.value === rankType ? 'border-blue-500 text-blue-500 border-b-2' : 'text-gray hover:text-black dark:hover:text-white'}`}
-          onClick={() => setRankType(option.value)}>
-          {option.label}
-        </button>
-      ))}
+    <div className='border-gray-200 flex justify-between border-b'>
+      <div>
+        {RANK_OPTIONS.map((option) => (
+          <button
+            key={option.value}
+            className={`px-4 py-2 ${option.value === rankType ? 'border-blue-500 text-blue-500 border-b-2' : 'text-gray hover:text-black dark:hover:text-white'}`}
+            onClick={() => setRankType(option.value)}>
+            {option.label}
+          </button>
+        ))}
+      </div>
+      <div className='flex items-center justify-center px-4'>
+        <InformationButton text='트래픽은 등록부터 어제까지, 나머지는 전날의 데이터만을 순위로 보여줍니다!' />
+      </div>
     </div>
   );
 }

--- a/frontend/src/component/organism/NavBar.tsx
+++ b/frontend/src/component/organism/NavBar.tsx
@@ -19,7 +19,7 @@ export default function Navbar() {
             <div className='flex-shrink-0'>
               <NavbarMenu />
             </div>
-            <div className='min-h-0 flex-1 overflow-y-scroll'>
+            <div className='scrollbar-hide min-h-0 flex-1 overflow-y-scroll'>
               <CustomErrorBoundary>
                 <NavbarRanking />
               </CustomErrorBoundary>

--- a/frontend/src/component/organism/ProjectTrafficChart.tsx
+++ b/frontend/src/component/organism/ProjectTrafficChart.tsx
@@ -138,7 +138,7 @@ export default function ProjectTrafficChart({ id }: Props) {
           <span className='mr-2 text-2xl font-bold'>{data.projectName}</span>
           Traffic Chart
         </div>
-        <div className='flex flex-1 justify-end'>
+        <div className='flex flex-1 justify-end p-4'>
           <Select
             cssOption='p-2 border rounded'
             options={DATE_OPTIONS}

--- a/frontend/src/component/organism/RankingList.tsx
+++ b/frontend/src/component/organism/RankingList.tsx
@@ -2,15 +2,13 @@ import RankingItem from '@component/molecule/RankingItem';
 import RankingTab from '@component/molecule/RankingTab';
 import DataLayout from '@component/template/DataLayout';
 import useRankData from '@hook/api/useRankData';
+import useNavbarStore from '@store/NavbarStore';
 import { RankType } from '@type/Rank';
 import { useState } from 'react';
 
-type Props = {
-  generation: string;
-};
-
-export default function RankingList({ generation }: Props) {
+export default function RankingList() {
   const [rankType, setRankType] = useState<RankType>('traffic');
+  const { generation } = useNavbarStore();
   const { data } = useRankData(rankType, generation);
 
   return (

--- a/frontend/src/component/page/RankingPage.tsx
+++ b/frontend/src/component/page/RankingPage.tsx
@@ -1,14 +1,11 @@
 import CustomErrorBoundary from '@boundary/CustomErrorBoundary';
 import RankingList from '@component/organism/RankingList';
-import useNavbarStore from '@store/NavbarStore';
 
 export default function RankingPage() {
-  const { generation } = useNavbarStore();
-
   return (
     <div className='flex h-screen w-full flex-col gap-[8px] p-[16px]'>
       <CustomErrorBoundary>
-        <RankingList generation={generation} />
+        <RankingList />
       </CustomErrorBoundary>
     </div>
   );

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,3 +1,4 @@
+import scrollbarHide from 'tailwind-scrollbar-hide';
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
@@ -21,5 +22,5 @@ export default {
       }
     }
   },
-  plugins: []
+  plugins: [scrollbarHide]
 };


### PR DESCRIPTION
### 👀 관련 이슈
#272

### ✨ 작업한 내용

1. 랭킹페이지의 랭킹이 어떤 데이터인지 호버 시 알려주는 정보버튼을 추가했습니다.
2. Navbar랭킹쪽에 스크롤바가 보이던 부분을 안보이도록 수정했습니다.

### 📷 스크린샷 또는 GIF

<img width="1145" alt="image" src="https://github.com/user-attachments/assets/92f2e51b-f3a5-4944-ab14-a3c4dd9d2e66">

